### PR TITLE
fix(api): safe-guard uploads handlers against null/invalid dates

### DIFF
--- a/api/routes/orgs/uploads.handlers.ts
+++ b/api/routes/orgs/uploads.handlers.ts
@@ -25,11 +25,7 @@ export class OrgUploadsHandler {
 
         ctx.var.logger.info({ uploadId, organizationId }, "Upload marked as completed");
 
-        return ctx.json({
-            ...record,
-            createdAt: record.createdAt.getTime(),
-            updatedAt: record.updatedAt.getTime(),
-        }, HttpStatusCodes.OK);
+        return ctx.json(record, HttpStatusCodes.OK);
     };
 
     static listUploads: AppHandler<typeof OrgUploadsRoutes.listUploads> = async (ctx) => {
@@ -38,11 +34,7 @@ export class OrgUploadsHandler {
         const uploadService = getUploadService(ctx);
         const uploads = await uploadService.listUploads(organizationId);
 
-        return ctx.json(uploads.map((u: any) => ({
-            ...u,
-            createdAt: u.createdAt.getTime(),
-            updatedAt: u.updatedAt.getTime(),
-        })), HttpStatusCodes.OK);
+        return ctx.json(uploads, HttpStatusCodes.OK);
     };
 
     static deleteUpload: AppHandler<typeof OrgUploadsRoutes.deleteUpload> = async (ctx) => {

--- a/shared/schemas/dto/upload.dto.ts
+++ b/shared/schemas/dto/upload.dto.ts
@@ -10,8 +10,8 @@ export const UploadResponseSchema = z.object({
     status: z.enum(["pending", "completed", "failed"]),
     organizationId: z.string(),
     uploadedBy: z.string(),
-    createdAt: z.number().or(z.date()).transform(d => new Date(d).getTime()),
-    updatedAt: z.number().or(z.date()).transform(d => new Date(d).getTime()),
+    createdAt: z.union([z.number(), z.date(), z.string(), z.null()]).optional().transform(d => d ? new Date(d).getTime() : Date.now()),
+    updatedAt: z.union([z.number(), z.date(), z.string(), z.null()]).optional().transform(d => d ? new Date(d).getTime() : Date.now()),
 }).openapi("UploadResponse");
 
 export type UploadDto = z.infer<typeof UploadResponseSchema>;


### PR DESCRIPTION
- Remove unsafe .getTime() calls in uploads.handlers.ts
- Update UploadResponseSchema to handle various date formats and null gaps