### PR TITLE
feat: enhance vocabulary processing and configuration

### DIFF
--- a/api/services/vocabulary-processing.service.ts
+++ b/api/services/vocabulary-processing.service.ts
@@ -65,7 +65,7 @@ export class VocabularyProcessingService {
             await this.vocabRepo.updateStatus(vocabularyId, "active");
         } catch (error: unknown) {
             await this.deps?.logPipelineFailure("text", vocabularyId, error);
-            // Leave status as processing_text for cron/queue retry; do not use `review`.
+            throw error;
         }
     }
 

--- a/api/services/vocabulary.service.ts
+++ b/api/services/vocabulary.service.ts
@@ -8,6 +8,8 @@ import { BaseService } from "./base.service";
 
 type CursorDirection = "next" | "prev";
 
+const RETRIABLE_STATUSES = new Set(["new", "processing_text"]);
+
 export class VocabularyService extends BaseService {
     constructor(
         private readonly vocabularyRepo: VocabularyBankRepository,
@@ -24,7 +26,7 @@ export class VocabularyService extends BaseService {
             throw new InternalServerError("Failed to create or load vocabulary item");
         }
 
-        if (item.status === "new") {
+        if (RETRIABLE_STATUSES.has(item.status)) {
             await this.queue.send({
                 type: "vocabulary.process-text",
                 vocabularyId: item.id,

--- a/tests/unit/vocabulary-processing.service.test.ts
+++ b/tests/unit/vocabulary-processing.service.test.ts
@@ -81,7 +81,7 @@ describe("VocabularyProcessingService", () => {
         expect(vocabRepo.updateStatus).not.toHaveBeenCalledWith("vocab_1", "active");
     });
 
-    it("processText keeps processing_text and logs pipeline failure on infra/parse errors (not review)", async () => {
+    it("processText leaves processing_text, logs pipeline failure, and rethrows on infra/parse errors (not review)", async () => {
         vocabRepo.findById.mockResolvedValueOnce({
             id: "vocab_1",
             text: "hello",
@@ -95,7 +95,7 @@ describe("VocabularyProcessingService", () => {
             logPipelineFailure,
         });
 
-        await service.processText("vocab_1");
+        await expect(service.processText("vocab_1")).rejects.toBeInstanceOf(Error);
 
         expect(vocabRepo.updateStatus).toHaveBeenCalledTimes(1);
         expect(vocabRepo.updateStatus).toHaveBeenNthCalledWith(1, "vocab_1", "processing_text");

--- a/tests/unit/vocabulary.service.test.ts
+++ b/tests/unit/vocabulary.service.test.ts
@@ -31,7 +31,7 @@ describe("VocabularyService", () => {
         );
     });
 
-    it("createVocabulary enqueues text processing only for new status", async () => {
+    it("createVocabulary enqueues text processing for new and processing_text statuses", async () => {
         vocabularyRepo.findOrCreate.mockResolvedValueOnce({
             ...makeVocabularyItem(),
             id: "vocab_1",
@@ -42,6 +42,19 @@ describe("VocabularyService", () => {
         expect(queue.send).toHaveBeenCalledWith({
             type: "vocabulary.process-text",
             vocabularyId: "vocab_1",
+        });
+
+        queue.send.mockClear();
+        vocabularyRepo.findOrCreate.mockResolvedValueOnce({
+            ...makeVocabularyItem({ text: "stuck", status: "processing_text" }),
+            id: "vocab_stuck",
+            status: "processing_text",
+        });
+
+        await service.createVocabulary("org_1", { text: "stuck" });
+        expect(queue.send).toHaveBeenCalledWith({
+            type: "vocabulary.process-text",
+            vocabularyId: "vocab_stuck",
         });
 
         queue.send.mockClear();

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -14,6 +14,9 @@
     },
     "env": {
         "development": {
+            "triggers": {
+                "crons": ["* * * * *"]
+            },
             "vars": {
                 "FRONTEND_URL": "http://localhost:8000",
                 "CORS_ORIGINS": "http://localhost:8000",
@@ -58,6 +61,9 @@
         "staging": {
             "name": "entix-app-staging",
             "preview_urls": true,
+            "triggers": {
+                "crons": ["* * * * *"]
+            },
             "vars": {
                 "FRONTEND_URL": "https://staging.entix.org",
                 "CORS_ORIGINS": "https://staging.entix.org",
@@ -107,6 +113,9 @@
         },
         "production": {
             "name": "entix-app",
+            "triggers": {
+                "crons": ["* * * * *"]
+            },
             "vars": {
                 "FRONTEND_URL": "https://entix.org",
                 "CORS_ORIGINS": "https://entix.org",


### PR DESCRIPTION
- Added cron triggers to development, staging, and production environments in wrangler.jsonc for scheduled tasks.
- Updated VocabularyProcessingService to rethrow errors instead of leaving status as processing_text, improving error handling.
- Modified VocabularyService to enqueue text processing for both new and processing_text statuses, allowing for better task management.
- Updated unit tests to reflect changes in error handling and vocabulary status processing.

## Summary

<!-- Briefly describe the goal of this PR. What is the business/architectural value? -->

## Ticket Link

<!-- Link to Jira / Linear / GitHub Issue (e.g., ENT-142) -->

## Type of Change

- [x] ✨ Feature  
- [ ] 🐛 Bug Fix  
- [ ] 🛠 Refactor  
- [ ] 📚 Documentation  
- [ ] 🧪 Testing  
- [ ] 🚀 Hotfix  

## Changes Made

<!-- List of specific modifications in bulleted format -->

- 💎 **Architecture**: (e.g., Migrated auth logic to Service layer)
- 📡 **Routes**: (e.g., Added GET /api/v1/playlists)
- 🗄️ **Database**: (e.g., New columns added to playlists table)
- 🎨 **UI**: (e.g., Updated sidebar UI for mobile responsive)

## How to Test

<!-- Step-by-step instructions for the reviewer. List specific test inputs or URLs. -->

1. 🌐 Navigate to `/org/:slug/dashboard`
2. 🖱️ Click "Add Playlist"
3. ✅ Confirm the playlist appears in the database and list

## Risks / Rollback Notes

- [ ] New environment variables added
- [ ] Database migration required
- [ ] High impact to existing functionality

## Screenshots (If UI changed)

<!-- Drop before/after screenshots here -->

---

## 🏗 Checklist

- [ ] **Typecheck**: `npm run typecheck:api` passes.
- [ ] **Tests**: `npm run test:api` (or relevant unit tests) passes.
- [ ] **Patterns**: No direct repository access from handlers. All DB logic is in Services.
- [ ] **Boundaries**: No external clients (Better Auth, Stripe, etc.) in Repositories.
- [ ] **Resilience**: `get*` methods have corresponding `NotFoundError` test cases.
- [ ] **Documentation**: `docs/` updated if new architecture patterns were introduced.
- [ ] **AI Context**: `docs/AI.md` updated if canonical rules changed.
