### PR TITLE
Hotfix/en 341/vocabulary pipeline stuck proc

### DIFF
--- a/api/helpers/ai.helpers.ts
+++ b/api/helpers/ai.helpers.ts
@@ -1,4 +1,9 @@
-import type { AiGenerateOptions, AiMessage, AiRunParams } from "@api/types/ai.types";
+import type {
+    AiGenerateDefaultsResolved,
+    AiGenerateOptions,
+    AiMessage,
+    AiRunParams,
+} from "@api/types/ai.types";
 
 /**
  * Resolves per-call option overrides against service-level defaults.
@@ -6,7 +11,7 @@ import type { AiGenerateOptions, AiMessage, AiRunParams } from "@api/types/ai.ty
  */
 export function resolveAiRunParams(
     overrides: AiGenerateOptions,
-    defaults: Required<AiGenerateOptions>
+    defaults: AiGenerateDefaultsResolved
 ): AiRunParams {
     return {
         max_tokens: overrides.maxTokens ?? defaults.maxTokens,

--- a/api/helpers/ai.helpers.ts
+++ b/api/helpers/ai.helpers.ts
@@ -12,6 +12,11 @@ export function resolveAiRunParams(
         max_tokens: overrides.maxTokens ?? defaults.maxTokens,
         temperature: overrides.temperature ?? defaults.temperature,
         top_p: overrides.topP ?? defaults.topP,
+        ...(overrides.responseFormat
+            ? { response_format: overrides.responseFormat }
+            : defaults.responseFormat
+              ? { response_format: defaults.responseFormat }
+              : {}),
     };
 }
 

--- a/api/queues/entix.queue.ts
+++ b/api/queues/entix.queue.ts
@@ -178,6 +178,8 @@ async function handleVocabularyProcessText(
     const aiService = new AiService({
         ai: env.AI,
         model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+        systemPrompt:
+            "You are a translation API. Respond with raw JSON only. No markdown, no code fences, no explanation. Your entire response must be a single valid JSON object.",
     });
     const processor = new VocabularyProcessingService(vocabularyRepo, aiService, {
         logPipelineFailure: async (_phase, vocabularyId, error) => {

--- a/api/services/ai.service.ts
+++ b/api/services/ai.service.ts
@@ -35,6 +35,7 @@ export class AiService extends BaseService {
             maxTokens: config.defaults?.maxTokens ?? 256,
             temperature: config.defaults?.temperature ?? 0.7,
             topP: config.defaults?.topP ?? 1,
+            responseFormat: config.defaults?.responseFormat,
         };
     }
 

--- a/api/services/ai.service.ts
+++ b/api/services/ai.service.ts
@@ -32,15 +32,12 @@ export class AiService extends BaseService {
         this.ai = config.ai;
         this.model = config.model;
         this.systemPrompt = config.systemPrompt;
-        const base: AiGenerateDefaultsResolved = {
+        this.defaults = {
             maxTokens: config.defaults?.maxTokens ?? 256,
             temperature: config.defaults?.temperature ?? 0.7,
             topP: config.defaults?.topP ?? 1,
+            responseFormat: config.defaults?.responseFormat,
         };
-        this.defaults =
-            config.defaults?.responseFormat !== undefined
-                ? { ...base, responseFormat: config.defaults.responseFormat }
-                : base;
     }
 
     async generate(prompt: string, options: AiGenerateOptions = {}): Promise<AiGenerateResult> {
@@ -80,6 +77,22 @@ export class AiService extends BaseService {
                 `Workers AI run failed for model "${this.model}": ${
                     error instanceof Error ? error.message : String(error)
                 }`
+            );
+        }
+
+        if (params.response_format) {
+            const extracted = extractAiText(response);
+            if (extracted !== null) {
+                return { text: extracted, generatedAt: new Date().toISOString() };
+            }
+            if (typeof response === "object" && response !== null) {
+                return {
+                    text: JSON.stringify(response),
+                    generatedAt: new Date().toISOString(),
+                };
+            }
+            throw new ServiceUnavailableError(
+                `Workers AI returned no JSON content for model "${this.model}".`
             );
         }
 

--- a/api/services/ai.service.ts
+++ b/api/services/ai.service.ts
@@ -1,6 +1,7 @@
 import { InternalServerError, ServiceUnavailableError } from "@api/errors/app.error";
 import { buildMessages, extractAiText, resolveAiRunParams } from "@api/helpers/ai.helpers";
 import type {
+    AiGenerateDefaultsResolved,
     AiGenerateOptions,
     AiGenerateResult,
     AiMessage,
@@ -16,7 +17,7 @@ export class AiService extends BaseService {
     private readonly ai: Ai;
     private readonly model: AiTextModel;
     private readonly systemPrompt: string | undefined;
-    private readonly defaults: Required<AiGenerateOptions>;
+    private readonly defaults: AiGenerateDefaultsResolved;
 
     constructor(config: AiServiceConfig) {
         super();
@@ -31,12 +32,15 @@ export class AiService extends BaseService {
         this.ai = config.ai;
         this.model = config.model;
         this.systemPrompt = config.systemPrompt;
-        this.defaults = {
+        const base: AiGenerateDefaultsResolved = {
             maxTokens: config.defaults?.maxTokens ?? 256,
             temperature: config.defaults?.temperature ?? 0.7,
             topP: config.defaults?.topP ?? 1,
-            responseFormat: config.defaults?.responseFormat,
         };
+        this.defaults =
+            config.defaults?.responseFormat !== undefined
+                ? { ...base, responseFormat: config.defaults.responseFormat }
+                : base;
     }
 
     async generate(prompt: string, options: AiGenerateOptions = {}): Promise<AiGenerateResult> {

--- a/api/services/vocabulary-processing.service.ts
+++ b/api/services/vocabulary-processing.service.ts
@@ -1,11 +1,23 @@
 import { InternalServerError } from "@api/errors/app.error";
 import type { VocabularyBankRepository } from "@api/repositories/vocabulary-bank.repository";
+import type { AiJsonSchema } from "@api/types/ai.types";
 import type { AiService } from "./ai.service";
 
 type VocabularyTranslation = {
     zh_translation: string;
     pinyin: string;
     needs_language_review?: boolean;
+};
+
+const VOCABULARY_TRANSLATION_SCHEMA: AiJsonSchema = {
+    type: "object",
+    properties: {
+        zh_translation: { type: "string" },
+        pinyin: { type: "string" },
+        needs_language_review: { type: "boolean" },
+    },
+    required: ["zh_translation", "pinyin", "needs_language_review"],
+    additionalProperties: false,
 };
 
 export type VocabularyProcessingDeps = {
@@ -34,16 +46,18 @@ export class VocabularyProcessingService {
 
         try {
             const prompt = [
-                "Translate the following English phrase to Mandarin Chinese.",
-                "Return strict JSON only with keys: zh_translation, pinyin, needs_language_review.",
-                "needs_language_review must be true only if the English phrase is likely misspelled, ungrammatical, or not sensible as study vocabulary.",
-                "If needs_language_review is true, still output your best-effort zh_translation and pinyin if possible.",
+                "Translate this English phrase to Mandarin Chinese.",
+                "Set needs_language_review to true only if the phrase is misspelled, ungrammatical, or unsuitable study vocabulary.",
                 `English phrase: "${item.text}"`,
             ].join("\n");
 
             const result = await this.aiService.generate(prompt, {
                 temperature: 0.1,
-                maxTokens: 256,
+                maxTokens: 512,
+                responseFormat: {
+                    type: "json_schema",
+                    json_schema: VOCABULARY_TRANSLATION_SCHEMA,
+                },
             });
 
             const parsed = parseVocabularyTranslation(result.text);
@@ -80,26 +94,24 @@ export class VocabularyProcessingService {
     }
 }
 
+/**
+ * Runtime type guard for model output.
+ * With response_format json_schema enabled, this is defensive validation rather than extraction.
+ */
 function parseVocabularyTranslation(
     raw: string
 ): VocabularyTranslation & { needs_language_review: boolean } {
-    const trimmed = raw.trim();
-
-    const objectCandidate = trimmed.startsWith("{")
-        ? trimmed
-        : trimmed.slice(trimmed.indexOf("{"), trimmed.lastIndexOf("}") + 1);
-
-    const parsed = JSON.parse(objectCandidate) as Partial<VocabularyTranslation> & {
-        needs_language_review?: boolean;
+    const parsed = JSON.parse(raw) as Partial<VocabularyTranslation> & {
+        needs_language_review?: unknown;
     };
-    const nlr = parsed.needs_language_review as boolean | string | undefined;
-    const needs_language_review = nlr === true || nlr === "true";
+    const needs_language_review = parsed.needs_language_review;
 
     if (
         typeof parsed.zh_translation !== "string" ||
         parsed.zh_translation.length === 0 ||
         typeof parsed.pinyin !== "string" ||
-        parsed.pinyin.length === 0
+        parsed.pinyin.length === 0 ||
+        typeof needs_language_review !== "boolean"
     ) {
         throw new InternalServerError("Invalid translation payload from AI");
     }

--- a/api/types/ai.types.ts
+++ b/api/types/ai.types.ts
@@ -30,7 +30,20 @@ export type AiGenerateOptions = {
     temperature?: number;
     /** Top-p nucleus sampling (0-1). */
     topP?: number;
+    /** Optional structured output mode supported by Workers AI compatible APIs. */
+    responseFormat?: AiResponseFormat;
 };
+
+export type AiJsonSchema = {
+    type: "object";
+    properties: Record<string, unknown>;
+    required?: string[];
+    additionalProperties?: boolean;
+};
+
+export type AiResponseFormat =
+    | { type: "json_object" }
+    | { type: "json_schema"; json_schema: AiJsonSchema };
 
 /**
  * Internal snake_case params passed directly to `ai.run()`.
@@ -40,6 +53,7 @@ export type AiRunParams = {
     max_tokens: number;
     temperature: number;
     top_p: number;
+    response_format?: AiResponseFormat;
 };
 
 /** Normalized response from non-streaming calls. */

--- a/api/types/ai.types.ts
+++ b/api/types/ai.types.ts
@@ -34,6 +34,15 @@ export type AiGenerateOptions = {
     responseFormat?: AiResponseFormat;
 };
 
+/**
+ * Resolved AiService defaults: sampling params are always set; structured output remains optional.
+ * (Avoids `Required<AiGenerateOptions>`, which would incorrectly require `responseFormat`.)
+ */
+export type AiGenerateDefaultsResolved = Required<
+    Pick<AiGenerateOptions, "maxTokens" | "temperature" | "topP">
+> &
+    Pick<AiGenerateOptions, "responseFormat">;
+
 export type AiJsonSchema = {
     type: "object";
     properties: Record<string, unknown>;

--- a/tests/integration/vocabulary.integration.test.ts
+++ b/tests/integration/vocabulary.integration.test.ts
@@ -20,6 +20,9 @@ describe("Vocabulary Integration Test", () => {
             where: eq(schema.authUsers.email, ownerEmail),
         });
         expect(owner).toBeDefined();
+        if (!owner) {
+            throw new Error("Expected organization owner to exist in authUsers");
+        }
 
         const [lesson] = await db
             .insert(schema.lessons)
@@ -38,7 +41,7 @@ describe("Vocabulary Integration Test", () => {
             .values({
                 organizationId: orgId,
                 lessonId: lesson.id,
-                teacherId: owner!.id,
+                teacherId: owner.id,
                 title: "Vocabulary Session",
                 startTime: new Date(),
                 durationMinutes: 60,
@@ -53,7 +56,7 @@ describe("Vocabulary Integration Test", () => {
             .values({
                 sessionId: session.id,
                 organizationId: orgId,
-                userId: owner!.id,
+                userId: owner.id,
                 joinedAt: new Date(),
                 absent: false,
                 paymentStatus: "unpaid",
@@ -71,7 +74,7 @@ describe("Vocabulary Integration Test", () => {
             .returning();
 
         await db.insert(schema.studentVocabulary).values({
-            userId: owner!.id,
+            userId: owner.id,
             organizationId: orgId,
             vocabularyId: vocab.id,
             attendanceId: attendance.id,

--- a/tests/unit/ai.helpers.test.ts
+++ b/tests/unit/ai.helpers.test.ts
@@ -15,6 +15,38 @@ describe("ai.helpers", () => {
         });
     });
 
+    it("forwards response_format when provided", () => {
+        const params = resolveAiRunParams(
+            {
+                responseFormat: {
+                    type: "json_schema",
+                    json_schema: {
+                        type: "object",
+                        properties: { foo: { type: "string" } },
+                        required: ["foo"],
+                        additionalProperties: false,
+                    },
+                },
+            },
+            { maxTokens: 256, temperature: 0.7, topP: 1, responseFormat: undefined }
+        );
+
+        expect(params).toEqual({
+            max_tokens: 256,
+            temperature: 0.7,
+            top_p: 1,
+            response_format: {
+                type: "json_schema",
+                json_schema: {
+                    type: "object",
+                    properties: { foo: { type: "string" } },
+                    required: ["foo"],
+                    additionalProperties: false,
+                },
+            },
+        });
+    });
+
     it("prepends system prompt when present", () => {
         const messages = buildMessages([{ role: "user", content: "hello" }], "system rules");
         expect(messages[0]).toEqual({ role: "system", content: "system rules" });

--- a/tests/unit/ai.helpers.test.ts
+++ b/tests/unit/ai.helpers.test.ts
@@ -28,7 +28,7 @@ describe("ai.helpers", () => {
                     },
                 },
             },
-            { maxTokens: 256, temperature: 0.7, topP: 1, responseFormat: undefined }
+            { maxTokens: 256, temperature: 0.7, topP: 1 }
         );
 
         expect(params).toEqual({

--- a/tests/unit/ai.service.test.ts
+++ b/tests/unit/ai.service.test.ts
@@ -49,6 +49,62 @@ describe("AiService", () => {
         await expect(service.generate("hello")).rejects.toBeInstanceOf(ServiceUnavailableError);
     });
 
+    it("response_format json_schema: serializes parsed object responses to text", async () => {
+        const payload = { zh_translation: "你好", pinyin: "nǐ hǎo", needs_language_review: false };
+        const run = vi.fn().mockResolvedValue(payload);
+        const service = new AiService({
+            ai: { run } as unknown as Ai,
+            model: "@cf/meta/llama-3.1-8b-instruct-fp8",
+            defaults: { maxTokens: 64, temperature: 0.2, topP: 0.9 },
+        });
+
+        const result = await service.generate("hello", {
+            responseFormat: {
+                type: "json_schema",
+                json_schema: {
+                    type: "object",
+                    properties: {
+                        zh_translation: { type: "string" },
+                        pinyin: { type: "string" },
+                        needs_language_review: { type: "boolean" },
+                    },
+                    required: ["zh_translation", "pinyin", "needs_language_review"],
+                    additionalProperties: false,
+                },
+            },
+        });
+
+        expect(result.text).toBe(JSON.stringify(payload));
+        const [, callPayload] = run.mock.calls[0] as [string, { response_format?: unknown }];
+        expect(callPayload.response_format).toEqual({
+            type: "json_schema",
+            json_schema: {
+                type: "object",
+                properties: {
+                    zh_translation: { type: "string" },
+                    pinyin: { type: "string" },
+                    needs_language_review: { type: "boolean" },
+                },
+                required: ["zh_translation", "pinyin", "needs_language_review"],
+                additionalProperties: false,
+            },
+        });
+    });
+
+    it("response_format: still accepts legacy { response: string } shape", async () => {
+        const run = vi.fn().mockResolvedValue({ response: '{"zh_translation":"x","pinyin":"y","needs_language_review":false}' });
+        const service = new AiService({
+            ai: { run } as unknown as Ai,
+            model: "@cf/meta/llama-3.1-8b-instruct-fp8",
+        });
+
+        const result = await service.generate("hello", {
+            responseFormat: { type: "json_object" },
+        });
+
+        expect(result.text).toBe('{"zh_translation":"x","pinyin":"y","needs_language_review":false}');
+    });
+
     it("returns stream output for streaming calls", async () => {
         const stream = new ReadableStream({
             start(controller) {

--- a/tests/unit/ai.service.test.ts
+++ b/tests/unit/ai.service.test.ts
@@ -92,7 +92,9 @@ describe("AiService", () => {
     });
 
     it("response_format: still accepts legacy { response: string } shape", async () => {
-        const run = vi.fn().mockResolvedValue({ response: '{"zh_translation":"x","pinyin":"y","needs_language_review":false}' });
+        const run = vi.fn().mockResolvedValue({
+            response: '{"zh_translation":"x","pinyin":"y","needs_language_review":false}',
+        });
         const service = new AiService({
             ai: { run } as unknown as Ai,
             model: "@cf/meta/llama-3.1-8b-instruct-fp8",
@@ -102,7 +104,21 @@ describe("AiService", () => {
             responseFormat: { type: "json_object" },
         });
 
-        expect(result.text).toBe('{"zh_translation":"x","pinyin":"y","needs_language_review":false}');
+        expect(result.text).toBe(
+            '{"zh_translation":"x","pinyin":"y","needs_language_review":false}'
+        );
+    });
+
+    it("response_format: throws when response is neither string nor object", async () => {
+        const run = vi.fn().mockResolvedValue(null);
+        const service = new AiService({
+            ai: { run } as unknown as Ai,
+            model: "@cf/meta/llama-3.1-8b-instruct-fp8",
+        });
+
+        await expect(
+            service.generate("hello", { responseFormat: { type: "json_object" } })
+        ).rejects.toBeInstanceOf(ServiceUnavailableError);
     });
 
     it("returns stream output for streaming calls", async () => {

--- a/tests/unit/vocabulary-processing.service.test.ts
+++ b/tests/unit/vocabulary-processing.service.test.ts
@@ -43,6 +43,23 @@ describe("VocabularyProcessingService", () => {
         );
         await service.processText("vocab_1");
 
+        expect(aiService.generate).toHaveBeenCalledWith(expect.stringContaining("English phrase"), {
+            temperature: 0.1,
+            maxTokens: 512,
+            responseFormat: {
+                type: "json_schema",
+                json_schema: {
+                    type: "object",
+                    properties: {
+                        zh_translation: { type: "string" },
+                        pinyin: { type: "string" },
+                        needs_language_review: { type: "boolean" },
+                    },
+                    required: ["zh_translation", "pinyin", "needs_language_review"],
+                    additionalProperties: false,
+                },
+            },
+        });
         expect(vocabRepo.updateStatus).toHaveBeenNthCalledWith(1, "vocab_1", "processing_text");
         expect(vocabRepo.updateStatus).toHaveBeenNthCalledWith(2, "vocab_1", "text_ready", {
             zhTranslation: "ni hao",


### PR DESCRIPTION
## Summary

<!-- Briefly describe the goal of this PR. What is the business/architectural value? -->

## Ticket Link

<!-- Link to Jira / Linear / GitHub Issue (e.g., ENT-142) -->

## Type of Change

- [ ] ✨ Feature  
- [x] 🐛 Bug Fix  
- [ ] 🛠 Refactor  
- [ ] 📚 Documentation  
- [ ] 🧪 Testing  
- [ ] 🚀 Hotfix  

## Changes Made

<!-- List of specific modifications in bulleted format -->

- 💎 **Architecture**: (e.g., Migrated auth logic to Service layer)
- 📡 **Routes**: (e.g., Added GET /api/v1/playlists)
- 🗄️ **Database**: (e.g., New columns added to playlists table)
- 🎨 **UI**: (e.g., Updated sidebar UI for mobile responsive)

## How to Test

<!-- Step-by-step instructions for the reviewer. List specific test inputs or URLs. -->

1. 🌐 Navigate to `/org/:slug/dashboard`
2. 🖱️ Click "Add Playlist"
3. ✅ Confirm the playlist appears in the database and list

## Risks / Rollback Notes

- [ ] New environment variables added
- [ ] Database migration required
- [ ] High impact to existing functionality

## Screenshots (If UI changed)

<!-- Drop before/after screenshots here -->

---

## 🏗 Checklist

- [ ] **Typecheck**: `npm run typecheck:api` passes.
- [ ] **Tests**: `npm run test:api` (or relevant unit tests) passes.
- [ ] **Patterns**: No direct repository access from handlers. All DB logic is in Services.
- [ ] **Boundaries**: No external clients (Better Auth, Stripe, etc.) in Repositories.
- [ ] **Resilience**: `get*` methods have corresponding `NotFoundError` test cases.
- [ ] **Documentation**: `docs/` updated if new architecture patterns were introduced.
- [ ] **AI Context**: `docs/AI.md` updated if canonical rules changed.
