### PR TITLE
feat: implement print functionality for bank statements

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -21,6 +21,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="print-root" aria-hidden="true"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/web/src/features/finance/components/ManageAccountDrawer.tsx
+++ b/web/src/features/finance/components/ManageAccountDrawer.tsx
@@ -8,6 +8,7 @@ import { FINANCIAL_CURRENCY_CONFIG, type WalletAccountDTO } from "@shared";
 import { TransactionAmount } from "@web/src/components/ui/TransactionAmount";
 import { useTransactionHistory } from "@web/src/features/wallet/hooks/useTransactionHistory";
 import { formatAccountDisplayName } from "@web/src/lib/account-display";
+import { StatementPrintDrawer } from "@web/src/reports";
 import { UI_CONSTANTS } from "@web/src/utils/constants";
 import {
     App,
@@ -26,7 +27,7 @@ import {
     theme,
 } from "antd";
 import type React from "react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useArchiveAccount, useUpdateAccount } from "../hooks/useAccountManagement";
 import { StudentFundingTab } from "./StudentFundingTab";
 
@@ -37,6 +38,8 @@ type Props = {
     onClose: () => void;
     account: WalletAccountDTO | null;
     orgId?: string;
+    orgName?: string;
+    logoUrl?: string | null;
     size?: "default" | "large";
 };
 
@@ -45,6 +48,8 @@ export const ManageAccountDrawer: React.FC<Props> = ({
     onClose,
     account,
     orgId,
+    orgName,
+    logoUrl,
     size = "default",
 }) => {
     const { notification } = App.useApp();
@@ -62,15 +67,6 @@ export const ManageAccountDrawer: React.FC<Props> = ({
         undefined,
         { accountId: account?.id }
     );
-
-    useEffect(() => {
-        if (open) {
-            setActiveTab("student-funding");
-        }
-        if (account) {
-            form.setFieldsValue({ name: account.name });
-        }
-    }, [open, account, form]);
 
     const handleUpdate = async (values: { name: string }) => {
         if (!account) return;
@@ -119,6 +115,14 @@ export const ManageAccountDrawer: React.FC<Props> = ({
             size={size}
             onClose={onClose}
             open={open}
+            afterOpenChange={(visible) => {
+                if (visible) {
+                    setActiveTab("student-funding");
+                    if (account) {
+                        form.setFieldsValue({ name: account.name });
+                    }
+                }
+            }}
             styles={{
                 body: { paddingBottom: 80 },
                 wrapper: {
@@ -126,17 +130,36 @@ export const ManageAccountDrawer: React.FC<Props> = ({
                 },
             }}
         >
-            <div style={{ marginBottom: 16 }}>
-                <Title level={4} style={{ margin: 0 }}>
-                    {formatAccountDisplayName(account.name, currencyMeta?.code)}
-                </Title>
-                <Space size={4} style={{ marginTop: 4 }}>
-                    <Tag color="success">ACTIVE</Tag>
-                    {account.accountType === "funding" && <Tag color="purple">FUNDING</Tag>}
-                    <Text type="secondary" style={{ fontSize: 12 }}>
-                        {currencyMeta?.code} • {account.id.split("_").pop()}
-                    </Text>
-                </Space>
+            <div
+                style={{
+                    marginBottom: 16,
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "flex-start",
+                    gap: 16,
+                    flexWrap: "wrap",
+                }}
+            >
+                <div style={{ flex: "1 1 auto", minWidth: 200 }}>
+                    <Title level={4} style={{ margin: 0 }}>
+                        {formatAccountDisplayName(account.name, currencyMeta?.code)}
+                    </Title>
+                    <Space size={4} style={{ marginTop: 4 }}>
+                        <Tag color="success">ACTIVE</Tag>
+                        {account.accountType === "funding" && <Tag color="purple">FUNDING</Tag>}
+                        <Text type="secondary" style={{ fontSize: 12 }}>
+                            {currencyMeta?.code} • {account.id.split("_").pop()}
+                        </Text>
+                    </Space>
+                </div>
+                {orgId ? (
+                    <StatementPrintDrawer
+                        account={account}
+                        orgId={orgId}
+                        orgName={orgName ?? "Organization"}
+                        logoUrl={logoUrl ?? undefined}
+                    />
+                ) : null}
             </div>
 
             <Tabs

--- a/web/src/features/lessons/hooks/useLessons.ts
+++ b/web/src/features/lessons/hooks/useLessons.ts
@@ -75,6 +75,25 @@ export function useLessons() {
     };
 }
 
+/** Fetch a single lesson by id (session exposes lessonId only — use this for titles). */
+export function useLessonById(organizationId: string | undefined, lessonId: string | undefined) {
+    const { isAuthenticated } = useAuth();
+
+    return useQuery({
+        queryKey: ["lesson", organizationId, lessonId],
+        enabled: !!organizationId && !!lessonId && isAuthenticated,
+        staleTime: QUERY_STALE_MS,
+        queryFn: async () => {
+            if (!organizationId || !lessonId) throw new Error("Organization and lesson required");
+            const api = getApiClient();
+            const res = await api.api.v1.orgs[":organizationId"].lessons[":lessonId"].$get({
+                param: { organizationId, lessonId },
+            });
+            return hcJson<LessonDto>(res);
+        },
+    });
+}
+
 export function useLessonLibrary(filters?: LessonFilters) {
     const { activeOrganization } = useOrganization();
     const { isAuthenticated } = useAuth();

--- a/web/src/features/vocabulary/components/AddVocabularyForm.tsx
+++ b/web/src/features/vocabulary/components/AddVocabularyForm.tsx
@@ -1,4 +1,6 @@
 import { Button, Form, Input } from "antd";
+import type { InputRef } from "antd/es/input";
+import { useRef } from "react";
 
 export function AddVocabularyForm({
     onSubmit,
@@ -8,10 +10,16 @@ export function AddVocabularyForm({
     isSubmitting: boolean;
 }) {
     const [form] = Form.useForm<{ text: string }>();
+    const inputRef = useRef<InputRef>(null);
 
     const handleFinish = async (values: { text: string }) => {
         await onSubmit(values.text.trim());
-        form.resetFields();
+        /** Avoid `resetFields()` — it drops focus. Clear value only so the user
+         * can immediately type the next word without clicking back into the field. */
+        form.setFieldsValue({ text: "" });
+        requestAnimationFrame(() => {
+            inputRef.current?.focus({ preventScroll: true });
+        });
     };
 
     return (
@@ -29,7 +37,7 @@ export function AddVocabularyForm({
                     { min: 1, message: "Vocabulary text cannot be empty" },
                 ]}
             >
-                <Input placeholder="Enter vocabulary text" allowClear />
+                <Input ref={inputRef} placeholder="Enter vocabulary text" allowClear />
             </Form.Item>
             <Form.Item className="mb-2">
                 <Button type="primary" htmlType="submit" loading={isSubmitting}>

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router";
 
 import "./index.css";
+import "./reports/core/print.css";
 import App from "./App.tsx";
 
 import { ThemeProvider } from "./providers/ThemeProvider.tsx";

--- a/web/src/pages/dashboard/billing/BillingAccountsPage.tsx
+++ b/web/src/pages/dashboard/billing/BillingAccountsPage.tsx
@@ -182,6 +182,8 @@ export const BillingAccountsPage: React.FC = () => {
                 onClose={() => setIsManageDrawerOpen(false)}
                 account={selectedAccount}
                 orgId={orgId}
+                orgName={activeOrganization?.name}
+                logoUrl={activeOrganization?.logo}
                 size="default"
             />
             <CreateAccountDrawer

--- a/web/src/pages/teaching/vocabulary/SessionVocabularyPage.tsx
+++ b/web/src/pages/teaching/vocabulary/SessionVocabularyPage.tsx
@@ -4,6 +4,7 @@ import { FINANCIAL_CATEGORIES, FINANCIAL_CURRENCIES, getAvatarUrl } from "@share
 import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { PageHeader } from "@web/src/components/layout/PageHeader";
 import { useOrgContext } from "@web/src/context/OrgContext";
+import { useLessonById } from "@web/src/features/lessons/hooks/useLessons";
 import { useOrgRole } from "@web/src/features/organization";
 import { useSessionById } from "@web/src/features/schedule";
 import { AddVocabularyForm, useVocabulary, VocabularyTable } from "@web/src/features/vocabulary";
@@ -14,11 +15,15 @@ import {
     POINTS_DRAFT_STEP,
     saveSessionPointsDraft,
 } from "@web/src/features/vocabulary/utils/sessionPointsDraft";
-import { countUniqueVocabularyWords } from "@web/src/features/vocabulary/utils/sessionVocabularyDisplay";
+import {
+    countUniqueVocabularyWords,
+    dedupeSessionVocabularyByWord,
+} from "@web/src/features/vocabulary/utils/sessionVocabularyDisplay";
 import { useWalletBalance } from "@web/src/features/wallet/hooks/useWalletBalance";
 import { useWalletTransfer } from "@web/src/features/wallet/hooks/useWalletTransfer";
 import { getApiClient } from "@web/src/lib/api-client";
 import { hcJson } from "@web/src/lib/hc-json";
+import { WordListPrintButton } from "@web/src/reports";
 import { App, Avatar, Button, Card, Result, Space, Table, Tag, Tooltip, Typography } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
@@ -47,6 +52,7 @@ export function SessionVocabularyPage() {
     const queryClient = useQueryClient();
 
     const sessionQuery = useSessionById(organizationId, sessionId);
+    const lessonQuery = useLessonById(organizationId, sessionQuery.data?.lessonId);
     const {
         items,
         isLoading,
@@ -599,7 +605,30 @@ export function SessionVocabularyPage() {
                 </Space>
             </Card>
 
-            <Card size="small" title={`Words for this session (${uniqueWordCount} unique)`}>
+            <Card
+                size="small"
+                title={`Words for this session (${uniqueWordCount} unique)`}
+                extra={
+                    organizationId && sessionQuery.data ? (
+                        <WordListPrintButton
+                            data={{
+                                sessionName: sessionQuery.data.title,
+                                lessonName:
+                                    lessonQuery.data?.title ?? sessionQuery.data.lessonId ?? "—",
+                                words: dedupeSessionVocabularyByWord(items).map(
+                                    (row) => row.vocabulary
+                                ),
+                                meta: {
+                                    title: "Vocabulary Word List",
+                                    orgName: activeOrganization?.name ?? "Organization",
+                                    logoUrl: activeOrganization?.logo ?? undefined,
+                                    generatedAt: new Date(),
+                                },
+                            }}
+                        />
+                    ) : null
+                }
+            >
                 <VocabularyTable
                     items={items}
                     loading={isLoading}

--- a/web/src/reports/core/PrintPortal.tsx
+++ b/web/src/reports/core/PrintPortal.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+interface PrintPortalProps {
+    children: ReactNode;
+}
+
+export function PrintPortal({ children }: PrintPortalProps) {
+    const el = document.getElementById("print-root");
+    if (!el) return null;
+    return createPortal(children, el);
+}

--- a/web/src/reports/core/buildPrintFileName.ts
+++ b/web/src/reports/core/buildPrintFileName.ts
@@ -1,0 +1,28 @@
+/**
+ * Builds the suggested PDF filename for printable documents.
+ *
+ * Format: `YYMMDD <primary> - <secondary>` (the browser appends `.pdf`
+ * automatically when "Save as PDF" is selected).
+ *
+ * Example: `260508 Tonson Liang - Seven Continents`
+ */
+export function buildPrintFileName(
+    primary: string,
+    secondary: string,
+    date: Date = new Date()
+): string {
+    const yy = String(date.getFullYear()).slice(2);
+    const mm = String(date.getMonth() + 1).padStart(2, "0");
+    const dd = String(date.getDate()).padStart(2, "0");
+    const datePrefix = `${yy}${mm}${dd}`;
+
+    /** Strip characters that are invalid in filenames on Windows/macOS and
+     * collapse runs of whitespace so the result is shell-safe. */
+    const sanitize = (s: string) =>
+        s
+            .replace(/[/\\:*?"<>|]/g, "")
+            .replace(/\s+/g, " ")
+            .trim();
+
+    return `${datePrefix} ${sanitize(primary)} - ${sanitize(secondary)}`;
+}

--- a/web/src/reports/core/print.css
+++ b/web/src/reports/core/print.css
@@ -1,0 +1,152 @@
+/**
+ * Print stylesheet for the reports module.
+ *
+ * `!important` is used liberally and intentionally: the host app ships a
+ * Tailwind reset, Ant Design CSS, and a Vidstack global stylesheet, all of
+ * which would otherwise cascade into the print mount and break the document.
+ * The whole point of this file is to defeat that cascade.
+ *
+ * biome-ignore-all lint/complexity/noImportantStyles: print isolation requires it
+ */
+
+#print-root {
+    display: none;
+}
+
+/* Hard-reset properties that could mirror or rotate the document — applied
+ * in screen and print contexts so the printed output is identical regardless
+ * of any rtl/transform inherited from the host app. */
+#print-root,
+#print-root * {
+    direction: ltr !important;
+    unicode-bidi: isolate;
+    transform: none !important;
+    writing-mode: horizontal-tb !important;
+}
+
+@media print {
+    #root {
+        display: none !important;
+    }
+
+    /* Reset body itself for print so nothing cascades into #print-root. */
+    body {
+        direction: ltr !important;
+        transform: none !important;
+        writing-mode: horizontal-tb !important;
+    }
+
+    /* Ant Design portals mount on body outside #root — hide them so print preview is clean */
+    .ant-drawer-root,
+    .ant-modal-root,
+    .ant-tooltip,
+    .ant-popover,
+    .ant-dropdown,
+    .ant-notification,
+    .ant-message {
+        display: none !important;
+    }
+
+    /* Belt-and-suspenders: hide every direct child of body except the print mount */
+    body > *:not(#print-root) {
+        display: none !important;
+    }
+    #print-root {
+        display: block !important;
+    }
+
+    @page {
+        size: A4 portrait;
+        margin: 18mm 15mm 20mm 15mm;
+
+        @bottom-right {
+            content: "Page " counter(page) " of " counter(pages);
+            font-size: 9pt;
+            color: #666;
+        }
+    }
+
+    body,
+    .doc-body {
+        font-family: "Inter", "Roboto", "Noto Sans", Arial, sans-serif;
+        font-size: 11pt;
+        line-height: 1.5;
+        color: #1a1a1a;
+    }
+
+    .doc-section {
+        break-inside: avoid;
+        page-break-inside: avoid;
+    }
+    .doc-table-row {
+        break-inside: avoid;
+        page-break-inside: avoid;
+    }
+    .doc-page-break {
+        break-before: page;
+        page-break-before: always;
+    }
+    .doc-no-break-after {
+        break-after: avoid;
+        page-break-after: avoid;
+    }
+
+    p,
+    li,
+    td,
+    th {
+        orphans: 3;
+        widows: 3;
+    }
+
+    .doc-layout {
+        width: 210mm;
+        min-height: 297mm;
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+    }
+
+    .doc-table {
+        width: 100%;
+        border-collapse: collapse;
+    }
+    .doc-table thead {
+        display: table-header-group;
+    }
+    .doc-table tfoot {
+        display: table-footer-group;
+    }
+    .doc-table td,
+    .doc-table th {
+        font-size: 10pt;
+        padding: 5pt 8pt;
+    }
+    .doc-table th {
+        background-color: #f0f0f0 !important;
+        font-weight: 600;
+        text-align: left;
+    }
+    .doc-table tbody tr:nth-child(even) td {
+        background-color: #f8f8f8 !important;
+        -webkit-print-color-adjust: exact;
+        print-color-adjust: exact;
+    }
+    .doc-table td,
+    .doc-table th {
+        border: 0.5pt solid #d0d0d0;
+    }
+
+    /* Strip decoration only inside the print document — leaving the rest
+     * of the page (which is hidden anyway) untouched. Scoped so specificity
+     * matches the other #print-root rules above. */
+    #print-root *,
+    body > #print-root * {
+        box-shadow: none !important;
+        text-shadow: none !important;
+    }
+    a {
+        text-decoration: none;
+        color: inherit;
+    }
+}

--- a/web/src/reports/core/usePrintDocument.ts
+++ b/web/src/reports/core/usePrintDocument.ts
@@ -1,0 +1,90 @@
+import type { ReactNode } from "react";
+import { useCallback, useEffect, useRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+export function usePrintDocument() {
+    const rootRef = useRef<Root | null>(null);
+    const printTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    /** Holds the title we overwrote so we can put it back when the print
+     * dialog closes (afterprint fires whether the user prints or cancels). */
+    const previousTitleRef = useRef<string | null>(null);
+    const restoreTitleHandlerRef = useRef<(() => void) | null>(null);
+
+    const cancelPendingPrint = useCallback(() => {
+        if (printTimeoutRef.current !== null) {
+            clearTimeout(printTimeoutRef.current);
+            printTimeoutRef.current = null;
+        }
+    }, []);
+
+    const restoreTitle = useCallback(() => {
+        if (previousTitleRef.current !== null) {
+            document.title = previousTitleRef.current;
+            previousTitleRef.current = null;
+        }
+        if (restoreTitleHandlerRef.current) {
+            window.removeEventListener("afterprint", restoreTitleHandlerRef.current);
+            restoreTitleHandlerRef.current = null;
+        }
+    }, []);
+
+    useEffect(() => {
+        return () => {
+            cancelPendingPrint();
+            restoreTitle();
+            const root = rootRef.current;
+            rootRef.current = null;
+            if (root) {
+                setTimeout(() => root.unmount(), 0);
+            }
+        };
+    }, [cancelPendingPrint, restoreTitle]);
+
+    const print = useCallback(
+        (documentNode: ReactNode, delayMs = 0, fileName?: string) => {
+            const container = document.getElementById("print-root");
+            if (!container) {
+                console.error("[usePrintDocument] #print-root element not found in index.html");
+                return;
+            }
+
+            cancelPendingPrint();
+
+            if (rootRef.current) {
+                rootRef.current.unmount();
+                rootRef.current = null;
+            }
+
+            rootRef.current = createRoot(container);
+            rootRef.current.render(documentNode);
+
+            printTimeoutRef.current = setTimeout(() => {
+                printTimeoutRef.current = null;
+                requestAnimationFrame(() => {
+                    requestAnimationFrame(() => {
+                        if (fileName) {
+                            /** Browsers seed the "Save as PDF" filename from
+                             * document.title; swap it for the duration of the
+                             * print dialog and restore on afterprint. */
+                            if (previousTitleRef.current === null) {
+                                previousTitleRef.current = document.title;
+                            }
+                            document.title = fileName;
+                            if (!restoreTitleHandlerRef.current) {
+                                restoreTitleHandlerRef.current = restoreTitle;
+                                window.addEventListener(
+                                    "afterprint",
+                                    restoreTitleHandlerRef.current
+                                );
+                            }
+                        }
+                        window.print();
+                    });
+                });
+            }, delayMs);
+        },
+        [cancelPendingPrint, restoreTitle]
+    );
+
+    return { print, cancelPendingPrint };
+}

--- a/web/src/reports/index.ts
+++ b/web/src/reports/index.ts
@@ -1,0 +1,35 @@
+export { buildPrintFileName } from "./core/buildPrintFileName";
+export { PrintPortal } from "./core/PrintPortal";
+export { usePrintDocument } from "./core/usePrintDocument";
+export { DocumentFooter } from "./shared/DocumentFooter";
+export { DocumentHeader } from "./shared/DocumentHeader";
+export { DocumentLayout } from "./shared/DocumentLayout";
+export { DocumentSection } from "./shared/DocumentSection";
+export type { DocumentMeta } from "./shared/document.types";
+export { BankStatementDocument } from "./templates/bank-statement/BankStatementDocument";
+export type {
+    BankStatementDocumentData,
+    BuildStatementDataOptions,
+} from "./templates/bank-statement/bank-statement.types";
+export { buildStatementData } from "./templates/bank-statement/bank-statement.types";
+export { StatementPrintDrawer } from "./templates/bank-statement/StatementPrintDrawer";
+export type { TransactionDirection } from "./templates/bank-statement/statement.utils";
+export {
+    compareTransactionsChronologically,
+    resolveTransactionDirection,
+} from "./templates/bank-statement/statement.utils";
+export type { StatementTransactionsResult } from "./templates/bank-statement/useStatementTransactions";
+export {
+    STATEMENT_TRANSACTION_HARD_CAP,
+    useStatementTransactions,
+} from "./templates/bank-statement/useStatementTransactions";
+export { WordListDocument } from "./templates/word-list/WordListDocument";
+export { WordListPrintButton } from "./templates/word-list/WordListPrintButton";
+export type {
+    PrintableVocabularyStatus,
+    WordListDocumentData,
+} from "./templates/word-list/word-list.types";
+export {
+    isPrintableVocabulary,
+    PRINTABLE_VOCABULARY_STATUSES,
+} from "./templates/word-list/word-list.types";

--- a/web/src/reports/shared/DocumentFooter.tsx
+++ b/web/src/reports/shared/DocumentFooter.tsx
@@ -1,0 +1,18 @@
+/** Visible footer line; page numbers come from @page rules in print.css. */
+export function DocumentFooter() {
+    return (
+        <footer
+            style={{
+                borderTop: "0.5pt solid #ccc",
+                marginTop: "20pt",
+                paddingTop: "6pt",
+                fontSize: "8pt",
+                color: "#888",
+                display: "flex",
+                justifyContent: "space-between",
+            }}
+        >
+            <span>Confidential — For internal use only</span>
+        </footer>
+    );
+}

--- a/web/src/reports/shared/DocumentHeader.tsx
+++ b/web/src/reports/shared/DocumentHeader.tsx
@@ -1,0 +1,56 @@
+import type { DocumentMeta } from "./document.types";
+
+interface DocumentHeaderProps {
+    meta: DocumentMeta;
+}
+
+export function DocumentHeader({ meta }: DocumentHeaderProps) {
+    const formattedDate = new Intl.DateTimeFormat("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+    }).format(meta.generatedAt);
+
+    return (
+        <header
+            className="doc-no-break-after"
+            style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "flex-start",
+                borderBottom: "1.5pt solid #1a1a1a",
+                paddingBottom: "10pt",
+                marginBottom: "16pt",
+            }}
+        >
+            <div style={{ display: "flex", alignItems: "center", gap: "10pt" }}>
+                {meta.logoUrl && (
+                    <img
+                        src={meta.logoUrl}
+                        alt={meta.orgName}
+                        style={{ height: "32pt", width: "auto", objectFit: "contain" }}
+                    />
+                )}
+                <div>
+                    <div style={{ fontSize: "13pt", fontWeight: 700, color: "#1a1a1a" }}>
+                        {meta.orgName}
+                    </div>
+                </div>
+            </div>
+
+            <div style={{ textAlign: "right" }}>
+                <div style={{ fontSize: "14pt", fontWeight: 700, color: "#1a1a1a" }}>
+                    {meta.title}
+                </div>
+                {meta.subtitle && (
+                    <div style={{ fontSize: "10pt", color: "#555", marginTop: "2pt" }}>
+                        {meta.subtitle}
+                    </div>
+                )}
+                <div style={{ fontSize: "9pt", color: "#777", marginTop: "4pt" }}>
+                    Generated: {formattedDate}
+                </div>
+            </div>
+        </header>
+    );
+}

--- a/web/src/reports/shared/DocumentLayout.tsx
+++ b/web/src/reports/shared/DocumentLayout.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+import { DocumentFooter } from "./DocumentFooter";
+import { DocumentHeader } from "./DocumentHeader";
+import type { DocumentMeta } from "./document.types";
+
+interface DocumentLayoutProps {
+    meta: DocumentMeta;
+    children: ReactNode;
+}
+
+export function DocumentLayout({ meta, children }: DocumentLayoutProps) {
+    return (
+        <div
+            className="doc-layout"
+            style={{
+                fontFamily: "Inter, Roboto, Arial, sans-serif",
+                /** Hard-reset every property that could mirror or rotate
+                 * inherited content from the host app's CSS or theme. */
+                direction: "ltr",
+                unicodeBidi: "isolate",
+                transform: "none",
+                writingMode: "horizontal-tb",
+                textAlign: "left",
+            }}
+        >
+            <DocumentHeader meta={meta} />
+            <main className="doc-body" style={{ padding: "0" }}>
+                {children}
+            </main>
+            <DocumentFooter />
+        </div>
+    );
+}

--- a/web/src/reports/shared/DocumentSection.tsx
+++ b/web/src/reports/shared/DocumentSection.tsx
@@ -1,0 +1,14 @@
+import type { CSSProperties, ReactNode } from "react";
+
+interface DocumentSectionProps {
+    children: ReactNode;
+    style?: CSSProperties;
+}
+
+export function DocumentSection({ children, style }: DocumentSectionProps) {
+    return (
+        <div className="doc-section" style={style}>
+            {children}
+        </div>
+    );
+}

--- a/web/src/reports/shared/document.types.ts
+++ b/web/src/reports/shared/document.types.ts
@@ -1,0 +1,8 @@
+/** Minimal contract every document template satisfies; templates extend their own data types. */
+export interface DocumentMeta {
+    title: string;
+    subtitle?: string;
+    orgName: string;
+    logoUrl?: string;
+    generatedAt: Date;
+}

--- a/web/src/reports/templates/bank-statement/BankStatementDocument.tsx
+++ b/web/src/reports/templates/bank-statement/BankStatementDocument.tsx
@@ -1,0 +1,21 @@
+import { DocumentLayout } from "../../shared/DocumentLayout";
+import type { BankStatementDocumentData } from "./bank-statement.types";
+import { StatementSummaryBlock } from "./StatementSummaryBlock";
+import { StatementTransactionTable } from "./StatementTransactionTable";
+
+interface BankStatementDocumentProps {
+    data: BankStatementDocumentData;
+}
+
+export function BankStatementDocument({ data }: BankStatementDocumentProps) {
+    return (
+        <DocumentLayout meta={data.meta}>
+            <StatementSummaryBlock data={data} />
+            <StatementTransactionTable
+                transactions={data.transactions}
+                accountId={data.account.id}
+                openingBalanceCents={data.openingBalanceCents}
+            />
+        </DocumentLayout>
+    );
+}

--- a/web/src/reports/templates/bank-statement/StatementPrintDrawer.tsx
+++ b/web/src/reports/templates/bank-statement/StatementPrintDrawer.tsx
@@ -1,0 +1,204 @@
+import { PrinterOutlined } from "@ant-design/icons";
+import type { WalletAccountDTO } from "@shared";
+import { Alert, Button, DatePicker, Drawer, Space, Statistic } from "antd";
+import type { Dayjs } from "dayjs";
+import dayjs from "dayjs";
+import { useMemo, useRef, useState } from "react";
+import { buildPrintFileName } from "../../core/buildPrintFileName";
+import { usePrintDocument } from "../../core/usePrintDocument";
+import { BankStatementDocument } from "./BankStatementDocument";
+import { buildStatementData } from "./bank-statement.types";
+import {
+    STATEMENT_TRANSACTION_HARD_CAP,
+    useStatementTransactions,
+} from "./useStatementTransactions";
+
+const { RangePicker } = DatePicker;
+
+/** Matches Ant Design Drawer close animation (~300ms) plus a small buffer before print. */
+const DRAWER_CLOSE_BEFORE_PRINT_MS = 350;
+
+type RangePreset = { label: string; value: [Dayjs, Dayjs] };
+
+/** Quick-pick presets for common statement periods. End-of-day is used
+ * for past ranges so the entire final day's transactions are included. */
+function buildRangePresets(): RangePreset[] {
+    const today = dayjs();
+    const startOfThisMonth = today.startOf("month");
+    const lastMonth = today.subtract(1, "month");
+    const startOfLastMonth = lastMonth.startOf("month");
+    const endOfLastMonth = lastMonth.endOf("month");
+    const startOfThisYear = today.startOf("year");
+    const lastYear = today.subtract(1, "year");
+    const startOfLastYear = lastYear.startOf("year");
+    const endOfLastYear = lastYear.endOf("year");
+
+    return [
+        { label: "This Month", value: [startOfThisMonth, today] },
+        { label: "Last Month", value: [startOfLastMonth, endOfLastMonth] },
+        { label: "Last 30 Days", value: [today.subtract(30, "day"), today] },
+        { label: "This Year", value: [startOfThisYear, today] },
+        { label: "Last Year", value: [startOfLastYear, endOfLastYear] },
+        { label: "Last 12 Months", value: [today.subtract(1, "year"), today] },
+    ];
+}
+
+interface StatementPrintDrawerProps {
+    account: WalletAccountDTO;
+    orgId: string;
+    orgName: string;
+    logoUrl?: string;
+}
+
+export function StatementPrintDrawer({
+    account,
+    orgId,
+    orgName,
+    logoUrl,
+}: StatementPrintDrawerProps) {
+    const [open, setOpen] = useState(false);
+    const [dateRange, setDateRange] = useState<[Date, Date]>(() => {
+        const now = new Date();
+        const firstOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+        return [firstOfMonth, now];
+    });
+
+    const closingForPrintRef = useRef(false);
+    const { print, cancelPendingPrint } = usePrintDocument();
+    /** Computed once per drawer mount; "today" doesn't need to track midnight rollovers. */
+    const presets = useMemo(() => buildRangePresets(), []);
+
+    /** Send full ISO timestamps spanning the full local day so the server
+     * (which compares against `new Date(filters.endDate)`) doesn't silently
+     * exclude transactions on the boundary days. Bare YYYY-MM-DD is parsed
+     * as midnight UTC, which truncates the end day on every timezone east
+     * of UTC and the start day on every timezone west of UTC. */
+    const startDate = dayjs(dateRange[0]).startOf("day").toISOString();
+    const endDate = dayjs(dateRange[1]).endOf("day").toISOString();
+
+    const { transactions, isLoading, isFetching, isExhausted, truncated, totalLoaded } =
+        useStatementTransactions({
+            orgId,
+            accountId: account.id,
+            startDate,
+            endDate,
+            enabled: open,
+        });
+
+    /** Closing balance can only be safely derived from account.balanceCents
+     * when the period ends today. For past periods we currently lack a
+     * balance-at-date endpoint; flag that to the user. */
+    const isCurrentPeriod = dayjs(dateRange[1]).isSame(dayjs(), "day");
+
+    const canPrint = isExhausted && !isFetching;
+
+    const handlePrint = () => {
+        if (!canPrint) return;
+        const statementData = buildStatementData(
+            account,
+            transactions,
+            dateRange[0],
+            dateRange[1],
+            orgName,
+            logoUrl
+        );
+        const periodLabel = dayjs(dateRange[0]).isSame(dateRange[1], "month")
+            ? `${dayjs(dateRange[0]).format("MMM YYYY")} Statement`
+            : `${dayjs(dateRange[0]).format("MMM YYYY")}–${dayjs(dateRange[1]).format("MMM YYYY")} Statement`;
+        const fileName = buildPrintFileName(account.name, periodLabel);
+        closingForPrintRef.current = true;
+        setOpen(false);
+        print(
+            <BankStatementDocument data={statementData} />,
+            DRAWER_CLOSE_BEFORE_PRINT_MS,
+            fileName
+        );
+    };
+
+    const handleDrawerClose = () => {
+        if (!closingForPrintRef.current) {
+            cancelPendingPrint();
+        }
+        setOpen(false);
+    };
+
+    return (
+        <>
+            <Button size="small" icon={<PrinterOutlined />} onClick={() => setOpen(true)}>
+                Print Statement
+            </Button>
+
+            <Drawer
+                title={`Statement — ${account.name}`}
+                placement="right"
+                width={420}
+                open={open}
+                onClose={handleDrawerClose}
+                afterOpenChange={(visible) => {
+                    if (!visible) {
+                        closingForPrintRef.current = false;
+                    }
+                }}
+                footer={
+                    <Button
+                        type="primary"
+                        icon={<PrinterOutlined />}
+                        block
+                        loading={isLoading || isFetching}
+                        disabled={!canPrint}
+                        onClick={handlePrint}
+                    >
+                        {canPrint ? "Print / Save as PDF" : "Loading transactions…"}
+                    </Button>
+                }
+            >
+                <Space direction="vertical" size="large" style={{ width: "100%" }}>
+                    <div>
+                        <div style={{ marginBottom: 8, fontWeight: 500 }}>Statement Period</div>
+                        <RangePicker
+                            style={{ width: "100%" }}
+                            value={[dayjs(dateRange[0]), dayjs(dateRange[1])]}
+                            presets={presets}
+                            allowClear={false}
+                            onChange={(dates) => {
+                                if (dates?.[0] && dates?.[1]) {
+                                    setDateRange([dates[0].toDate(), dates[1].toDate()]);
+                                }
+                            }}
+                        />
+                    </div>
+
+                    <div style={{ background: "#fafafa", borderRadius: 8, padding: 16 }}>
+                        <Statistic
+                            title="Transactions in period"
+                            value={isLoading ? "…" : totalLoaded}
+                        />
+                    </div>
+
+                    {truncated && (
+                        <Alert
+                            type="warning"
+                            showIcon
+                            message="Statement truncated"
+                            description={`More than ${STATEMENT_TRANSACTION_HARD_CAP} transactions were found in this period. Only the first ${STATEMENT_TRANSACTION_HARD_CAP} will be printed. Narrow the date range for a complete statement.`}
+                        />
+                    )}
+
+                    {!isCurrentPeriod && (
+                        <Alert
+                            type="info"
+                            showIcon
+                            message="Closing balance is the live account balance"
+                            description="This statement uses the account's current balance as the closing balance. If transactions occurred after the period end, the opening balance figure may be off. Use today's date as the end date for an exact statement."
+                        />
+                    )}
+
+                    <div style={{ color: "#888", fontSize: 12 }}>
+                        Use your browser&apos;s print dialog to save as PDF. Set paper size to A4
+                        for best results.
+                    </div>
+                </Space>
+            </Drawer>
+        </>
+    );
+}

--- a/web/src/reports/templates/bank-statement/StatementPrintDrawer.tsx
+++ b/web/src/reports/templates/bank-statement/StatementPrintDrawer.tsx
@@ -90,7 +90,11 @@ export function StatementPrintDrawer({
      * balance-at-date endpoint; flag that to the user. */
     const isCurrentPeriod = dayjs(dateRange[1]).isSame(dayjs(), "day");
 
-    const canPrint = isExhausted && !isFetching;
+    /** Allow printing either once the range has been fully exhausted or once
+     * we've deliberately stopped paginating at the hard cap. In the truncated
+     * case the UI already communicates that only the first N transactions
+     * will be printed. */
+    const canPrint = (isExhausted || truncated) && !isFetching;
 
     const handlePrint = () => {
         if (!canPrint) return;

--- a/web/src/reports/templates/bank-statement/StatementSummaryBlock.tsx
+++ b/web/src/reports/templates/bank-statement/StatementSummaryBlock.tsx
@@ -1,0 +1,64 @@
+import { FINANCIAL_CURRENCY_CONFIG } from "@shared";
+import { DocumentSection } from "../../shared/DocumentSection";
+import type { BankStatementDocumentData } from "./bank-statement.types";
+
+function formatCents(cents: number, symbol: string): string {
+    return `${symbol}${(cents / 100).toFixed(2)}`;
+}
+
+function formatDate(d: Date): string {
+    return new Intl.DateTimeFormat("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+    }).format(d);
+}
+
+interface SummaryBlockProps {
+    data: BankStatementDocumentData;
+}
+
+export function StatementSummaryBlock({ data }: SummaryBlockProps) {
+    const currencyConfig =
+        FINANCIAL_CURRENCY_CONFIG[
+            data.account.currencyId as keyof typeof FINANCIAL_CURRENCY_CONFIG
+        ];
+    const sym = data.transactions[0]?.currency?.symbol ?? currencyConfig?.symbol ?? "$";
+    const currencyLabel =
+        data.transactions[0]?.currency?.code ?? currencyConfig?.code ?? data.account.currencyId;
+
+    const rows: [string, string][] = [
+        ["Account Name", data.account.name],
+        ["Account Type", data.account.accountType],
+        ["Currency", currencyLabel],
+        ["Statement Period", `${formatDate(data.periodFrom)} — ${formatDate(data.periodTo)}`],
+        ["Opening Balance", formatCents(data.openingBalanceCents, sym)],
+        ["Closing Balance", formatCents(data.closingBalanceCents, sym)],
+        ["Total Credits", formatCents(data.totalCreditCents, sym)],
+        ["Total Debits", formatCents(data.totalDebitCents, sym)],
+    ];
+
+    return (
+        <DocumentSection style={{ marginBottom: "14pt" }}>
+            <table style={{ width: "60%", borderCollapse: "collapse", fontSize: "10pt" }}>
+                <tbody>
+                    {rows.map(([label, value]) => (
+                        <tr key={label}>
+                            <td style={{ padding: "3pt 8pt 3pt 0", color: "#555", width: "45%" }}>
+                                {label}
+                            </td>
+                            <td
+                                style={{
+                                    padding: "3pt 0",
+                                    fontWeight: label.includes("Balance") ? 600 : 400,
+                                }}
+                            >
+                                {value}
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </DocumentSection>
+    );
+}

--- a/web/src/reports/templates/bank-statement/StatementTransactionRow.tsx
+++ b/web/src/reports/templates/bank-statement/StatementTransactionRow.tsx
@@ -1,0 +1,41 @@
+import type { Transaction } from "@web/src/features/wallet/hooks/useTransactionHistory";
+import { resolveTransactionDirection } from "./statement.utils";
+
+interface StatementTransactionRowProps {
+    tx: Transaction;
+    accountId: string;
+    runningBalance: number;
+}
+
+export function StatementTransactionRow({
+    tx,
+    accountId,
+    runningBalance,
+}: StatementTransactionRowProps) {
+    const direction = resolveTransactionDirection(tx, accountId);
+    const isCredit = direction === "credit";
+    const sym = tx.currency.symbol;
+    const formatted = (cents: number) => `${sym}${(cents / 100).toFixed(2)}`;
+    const date = new Intl.DateTimeFormat("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+    }).format(new Date(tx.transactionDate));
+
+    return (
+        <tr className="doc-table-row">
+            <td style={{ width: "13%" }}>{date}</td>
+            <td style={{ width: "28%" }}>{tx.description ?? tx.category.name}</td>
+            <td style={{ width: "18%", color: "#555", fontSize: "9pt" }}>{tx.id.slice(0, 12)}…</td>
+            <td style={{ width: "14%", textAlign: "right", color: "#c0392b" }}>
+                {!isCredit ? formatted(tx.amountCents) : ""}
+            </td>
+            <td style={{ width: "14%", textAlign: "right", color: "#27ae60" }}>
+                {isCredit ? formatted(tx.amountCents) : ""}
+            </td>
+            <td style={{ width: "13%", textAlign: "right", fontWeight: 500 }}>
+                {formatted(runningBalance)}
+            </td>
+        </tr>
+    );
+}

--- a/web/src/reports/templates/bank-statement/StatementTransactionTable.tsx
+++ b/web/src/reports/templates/bank-statement/StatementTransactionTable.tsx
@@ -1,0 +1,85 @@
+import type { Transaction } from "@web/src/features/wallet/hooks/useTransactionHistory";
+import { StatementTransactionRow } from "./StatementTransactionRow";
+import { resolveTransactionDirection } from "./statement.utils";
+
+interface StatementTransactionTableProps {
+    transactions: Transaction[];
+    accountId: string;
+    openingBalanceCents: number;
+}
+
+interface BalancedRow {
+    tx: Transaction;
+    balance: number;
+}
+
+/** Pure helper kept at module scope so we can mutate a local accumulator
+ * (push + running `let`) without tripping React's immutability lint, and
+ * still avoid the O(n²) accumulating-spread pattern Biome flags inside
+ * `Array.prototype.reduce`. */
+function computeRunningBalances(
+    transactions: Transaction[],
+    accountId: string,
+    openingBalanceCents: number
+): BalancedRow[] {
+    const rows: BalancedRow[] = [];
+    let runningBalance = openingBalanceCents;
+    for (const tx of transactions) {
+        const direction = resolveTransactionDirection(tx, accountId);
+        runningBalance =
+            direction === "credit"
+                ? runningBalance + tx.amountCents
+                : runningBalance - tx.amountCents;
+        rows.push({ tx, balance: runningBalance });
+    }
+    return rows;
+}
+
+export function StatementTransactionTable({
+    transactions,
+    accountId,
+    openingBalanceCents,
+}: StatementTransactionTableProps) {
+    /** Walk transactions chronologically (oldest → newest) so each row's
+     * running balance is the post-transaction balance at that moment. */
+    const rowsWithBalance = computeRunningBalances(transactions, accountId, openingBalanceCents);
+
+    /** Display newest first while preserving each row's already-computed
+     * running balance — the first row shows the closing balance. */
+    const displayRows = rowsWithBalance.slice().reverse();
+
+    return (
+        <table className="doc-table">
+            <thead>
+                <tr>
+                    <th style={{ width: "13%" }}>Date</th>
+                    <th style={{ width: "28%" }}>Description</th>
+                    <th style={{ width: "18%" }}>Reference</th>
+                    <th style={{ width: "14%", textAlign: "right" }}>Debit</th>
+                    <th style={{ width: "14%", textAlign: "right" }}>Credit</th>
+                    <th style={{ width: "13%", textAlign: "right" }}>Balance</th>
+                </tr>
+            </thead>
+            <tbody>
+                {displayRows.map(({ tx, balance: rowBalance }) => (
+                    <StatementTransactionRow
+                        key={tx.id}
+                        tx={tx}
+                        accountId={accountId}
+                        runningBalance={rowBalance}
+                    />
+                ))}
+                {displayRows.length === 0 && (
+                    <tr>
+                        <td
+                            colSpan={6}
+                            style={{ textAlign: "center", padding: "12pt", color: "#888" }}
+                        >
+                            No transactions in this period
+                        </td>
+                    </tr>
+                )}
+            </tbody>
+        </table>
+    );
+}

--- a/web/src/reports/templates/bank-statement/bank-statement.types.ts
+++ b/web/src/reports/templates/bank-statement/bank-statement.types.ts
@@ -1,0 +1,78 @@
+import type { WalletAccountDTO } from "@shared";
+import type { Transaction } from "@web/src/features/wallet/hooks/useTransactionHistory";
+import type { DocumentMeta } from "../../shared/document.types";
+import { compareTransactionsChronologically, resolveTransactionDirection } from "./statement.utils";
+
+export interface BankStatementDocumentData {
+    account: WalletAccountDTO;
+    transactions: Transaction[];
+    periodFrom: Date;
+    periodTo: Date;
+    openingBalanceCents: number;
+    closingBalanceCents: number;
+    totalCreditCents: number;
+    totalDebitCents: number;
+    /** True when closingBalanceCents was derived from account.balanceCents
+     * rather than an authoritative balance-at-date. Templates can use this
+     * to show a disclaimer when the period extends beyond the live balance. */
+    closingBalanceIsLive: boolean;
+    meta: DocumentMeta;
+}
+
+export interface BuildStatementDataOptions {
+    /**
+     * Authoritative closing balance at periodTo, in cents. When omitted,
+     * we fall back to account.balanceCents — which is only correct when
+     * periodTo is the current moment AND no transactions occurred after it.
+     * Pass this when the API exposes a balance-at-date endpoint.
+     */
+    closingBalanceCentsOverride?: number;
+}
+
+export function buildStatementData(
+    account: WalletAccountDTO,
+    transactions: Transaction[],
+    periodFrom: Date,
+    periodTo: Date,
+    orgName: string,
+    logoUrl?: string,
+    options?: BuildStatementDataOptions
+): BankStatementDocumentData {
+    const completed = transactions
+        .filter((t) => t.status === "completed")
+        .slice()
+        .sort(compareTransactionsChronologically);
+
+    const totalCreditCents = completed
+        .filter((t) => resolveTransactionDirection(t, account.id) === "credit")
+        .reduce((sum, t) => sum + t.amountCents, 0);
+
+    const totalDebitCents = completed
+        .filter((t) => resolveTransactionDirection(t, account.id) === "debit")
+        .reduce((sum, t) => sum + t.amountCents, 0);
+
+    const hasOverride = options?.closingBalanceCentsOverride !== undefined;
+    const closingBalanceCents = hasOverride
+        ? (options?.closingBalanceCentsOverride as number)
+        : account.balanceCents;
+    const openingBalanceCents = closingBalanceCents - totalCreditCents + totalDebitCents;
+
+    return {
+        account,
+        transactions: completed,
+        periodFrom,
+        periodTo,
+        openingBalanceCents,
+        closingBalanceCents,
+        totalCreditCents,
+        totalDebitCents,
+        closingBalanceIsLive: !hasOverride,
+        meta: {
+            title: "Account Statement",
+            subtitle: account.name,
+            orgName,
+            logoUrl,
+            generatedAt: new Date(),
+        },
+    };
+}

--- a/web/src/reports/templates/bank-statement/statement.utils.ts
+++ b/web/src/reports/templates/bank-statement/statement.utils.ts
@@ -1,0 +1,22 @@
+import type { Transaction } from "@web/src/features/wallet/hooks/useTransactionHistory";
+
+export type TransactionDirection = "credit" | "debit";
+
+/**
+ * Determines whether a transaction credits or debits the given account.
+ * Single source of truth for direction-derived display logic in the bank
+ * statement template.
+ */
+export function resolveTransactionDirection(
+    tx: Transaction,
+    accountId: string
+): TransactionDirection {
+    return tx.destinationAccountId === accountId ? "credit" : "debit";
+}
+
+export function compareTransactionsChronologically(a: Transaction, b: Transaction): number {
+    const da = new Date(a.transactionDate).getTime();
+    const db = new Date(b.transactionDate).getTime();
+    if (da !== db) return da - db;
+    return a.id.localeCompare(b.id);
+}

--- a/web/src/reports/templates/bank-statement/useStatementTransactions.ts
+++ b/web/src/reports/templates/bank-statement/useStatementTransactions.ts
@@ -1,0 +1,112 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import type {
+    Transaction,
+    TransactionHistoryResponse,
+} from "@web/src/features/wallet/hooks/useTransactionHistory";
+import { getApiClient } from "@web/src/lib/api-client";
+import { hcJson } from "@web/src/lib/hc-json";
+import { QUERY_STALE_MS } from "@web/src/lib/query-config";
+import { useEffect, useMemo } from "react";
+
+/** Hard cap so a runaway range can't fetch unbounded pages. Narrow the
+ * date range to stay below this; the drawer surfaces a warning when hit. */
+export const STATEMENT_TRANSACTION_HARD_CAP = 500;
+
+/** Maximum page size accepted by the API (`paginationSchema.limit.max(100)`). */
+const STATEMENT_PAGE_SIZE = 100;
+
+interface UseStatementTransactionsArgs {
+    orgId: string;
+    accountId: string;
+    /** YYYY-MM-DD inclusive */
+    startDate: string;
+    /** YYYY-MM-DD inclusive */
+    endDate: string;
+    enabled?: boolean;
+}
+
+export interface StatementTransactionsResult {
+    transactions: Transaction[];
+    /** True only on the very first fetch (page 1). */
+    isLoading: boolean;
+    /** True on any in-flight fetch including pagination. */
+    isFetching: boolean;
+    /** True once every page in the range has been loaded; safe to print. */
+    isExhausted: boolean;
+    /** True when the hard cap was hit before exhaustion. */
+    truncated: boolean;
+    totalLoaded: number;
+}
+
+/**
+ * Fetches every completed transaction in the date range for a single
+ * account, cursoring through pages until exhaustion or the hard cap.
+ * Used by the bank statement template so printed statements never
+ * silently truncate.
+ *
+ * The auto-pagination effect destructures stable primitives from the
+ * query result; the React-Query result object is a fresh reference on
+ * every render, so depending on it directly thrashes the loop.
+ */
+export function useStatementTransactions({
+    orgId,
+    accountId,
+    startDate,
+    endDate,
+    enabled = true,
+}: UseStatementTransactionsArgs): StatementTransactionsResult {
+    const query = useInfiniteQuery<TransactionHistoryResponse>({
+        queryKey: ["statementTransactions", orgId, accountId, startDate, endDate],
+        queryFn: async ({ pageParam }) => {
+            const api = getApiClient();
+            const res = await api.api.v1.orgs[":organizationId"].finance.transactions.$get({
+                param: { organizationId: orgId },
+                query: {
+                    limit: STATEMENT_PAGE_SIZE,
+                    cursor: (pageParam as string | undefined) ?? undefined,
+                    startDate,
+                    endDate,
+                    accountId,
+                    status: "completed",
+                },
+            });
+            return hcJson<TransactionHistoryResponse>(res);
+        },
+        initialPageParam: undefined as string | undefined,
+        getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+        enabled: enabled && !!orgId && !!accountId,
+        staleTime: QUERY_STALE_MS,
+    });
+
+    const transactions = useMemo(
+        () => (query.data?.pages ?? []).flatMap((p) => p.data),
+        [query.data]
+    );
+    const totalLoaded = transactions.length;
+    const truncated = totalLoaded >= STATEMENT_TRANSACTION_HARD_CAP;
+
+    /** Stable primitives — never put `query` itself in deps; React Query
+     * returns a fresh result object on every render which would thrash
+     * this effect and short-circuit the pagination loop. */
+    const { isFetching, isFetchingNextPage, hasNextPage, fetchNextPage } = query;
+
+    useEffect(() => {
+        if (!enabled) return;
+        if (isFetching || isFetchingNextPage) return;
+        if (!hasNextPage) return;
+        if (truncated) return;
+        void fetchNextPage();
+    }, [enabled, truncated, isFetching, isFetchingNextPage, hasNextPage, fetchNextPage]);
+
+    /** Safe to print only when every page has settled. */
+    const isExhausted = !hasNextPage && !isFetching && !isFetchingNextPage;
+
+    return {
+        transactions,
+        isLoading: query.isLoading,
+        isFetching: isFetching || isFetchingNextPage,
+        isExhausted,
+        truncated,
+        totalLoaded,
+    };
+}

--- a/web/src/reports/templates/word-list/WordListDocument.tsx
+++ b/web/src/reports/templates/word-list/WordListDocument.tsx
@@ -1,0 +1,27 @@
+import { DocumentLayout } from "../../shared/DocumentLayout";
+import { DocumentSection } from "../../shared/DocumentSection";
+import { WordListTable } from "./WordListTable";
+import { isPrintableVocabulary, type WordListDocumentData } from "./word-list.types";
+
+interface WordListDocumentProps {
+    data: WordListDocumentData;
+}
+
+export function WordListDocument({ data }: WordListDocumentProps) {
+    const printableWords = data.words.filter(isPrintableVocabulary);
+
+    return (
+        <DocumentLayout meta={data.meta}>
+            <DocumentSection>
+                <div style={{ marginBottom: "12pt" }}>
+                    <div style={{ fontSize: "12pt", fontWeight: 700 }}>{data.sessionName}</div>
+                    <div style={{ fontSize: "10pt", color: "#555" }}>Lesson: {data.lessonName}</div>
+                    <div style={{ fontSize: "9pt", color: "#888", marginTop: "3pt" }}>
+                        {printableWords.length} word{printableWords.length !== 1 ? "s" : ""}
+                    </div>
+                </div>
+                <WordListTable words={printableWords} />
+            </DocumentSection>
+        </DocumentLayout>
+    );
+}

--- a/web/src/reports/templates/word-list/WordListPrintButton.tsx
+++ b/web/src/reports/templates/word-list/WordListPrintButton.tsx
@@ -1,0 +1,33 @@
+import { PrinterOutlined } from "@ant-design/icons";
+import { Button } from "antd";
+import { buildPrintFileName } from "../../core/buildPrintFileName";
+import { usePrintDocument } from "../../core/usePrintDocument";
+import { WordListDocument } from "./WordListDocument";
+import type { WordListDocumentData } from "./word-list.types";
+
+/** Extra delay before window.print() so fonts/IPA layout settle (no drawer close needed). */
+const DEFAULT_WORD_LIST_PRINT_DELAY_MS = 200;
+
+interface WordListPrintButtonProps {
+    data: WordListDocumentData;
+    /** Overrides delay before print dialog (default 200ms). */
+    printDelayMs?: number;
+}
+
+export function WordListPrintButton({
+    data,
+    printDelayMs = DEFAULT_WORD_LIST_PRINT_DELAY_MS,
+}: WordListPrintButtonProps) {
+    const { print } = usePrintDocument();
+
+    const handlePrint = () => {
+        const fileName = buildPrintFileName(data.sessionName, data.lessonName);
+        print(<WordListDocument data={data} />, printDelayMs, fileName);
+    };
+
+    return (
+        <Button size="small" icon={<PrinterOutlined />} onClick={handlePrint}>
+            Print Word List
+        </Button>
+    );
+}

--- a/web/src/reports/templates/word-list/WordListRow.tsx
+++ b/web/src/reports/templates/word-list/WordListRow.tsx
@@ -1,0 +1,23 @@
+import type { VocabularyItemDTO } from "@web/src/features/vocabulary/hooks/useVocabulary";
+
+interface WordListRowProps {
+    word: VocabularyItemDTO;
+    index: number;
+}
+
+export function WordListRow({ word, index }: WordListRowProps) {
+    return (
+        <tr className="doc-table-row">
+            <td style={{ width: "6%", color: "#888", textAlign: "center" }}>{index + 1}</td>
+            <td style={{ width: "20%", fontWeight: 600 }}>{word.text}</td>
+            {/* Single-font IPA cell: a fallback chain caused glyph-metric mismatch
+             * between the visible text and the browser's hit-test layer, which
+             * made selection land in apparently empty space. */}
+            <td style={{ width: "18%", fontFamily: "Arial, sans-serif", color: "#444" }}>
+                {word.ipaUs ?? ""}
+            </td>
+            <td style={{ width: "38%", color: "#222" }}>{word.definitionSimple ?? ""}</td>
+            <td style={{ width: "18%" }}>{word.zhTranslation ?? ""}</td>
+        </tr>
+    );
+}

--- a/web/src/reports/templates/word-list/WordListTable.tsx
+++ b/web/src/reports/templates/word-list/WordListTable.tsx
@@ -1,0 +1,27 @@
+import type { VocabularyItemDTO } from "@web/src/features/vocabulary/hooks/useVocabulary";
+import { WordListRow } from "./WordListRow";
+
+interface WordListTableProps {
+    words: VocabularyItemDTO[];
+}
+
+export function WordListTable({ words }: WordListTableProps) {
+    return (
+        <table className="doc-table" style={{ marginTop: "10pt" }}>
+            <thead>
+                <tr>
+                    <th style={{ width: "6%" }}>#</th>
+                    <th style={{ width: "20%" }}>English</th>
+                    <th style={{ width: "18%" }}>Phonetic (IPA)</th>
+                    <th style={{ width: "38%" }}>Definition</th>
+                    <th style={{ width: "18%" }}>Chinese</th>
+                </tr>
+            </thead>
+            <tbody>
+                {words.map((word, i) => (
+                    <WordListRow key={word.id} word={word} index={i} />
+                ))}
+            </tbody>
+        </table>
+    );
+}

--- a/web/src/reports/templates/word-list/word-list.types.ts
+++ b/web/src/reports/templates/word-list/word-list.types.ts
@@ -1,0 +1,28 @@
+import type {
+    VocabularyItemDTO,
+    VocabularyStatus,
+} from "@web/src/features/vocabulary/hooks/useVocabulary";
+import type { DocumentMeta } from "../../shared/document.types";
+
+/** Statuses that represent a vocabulary item that is finalized enough to
+ * be included in printed materials. Any new printable status (e.g.
+ * "approved") must be added here explicitly so we never silently exclude
+ * words from a printout. */
+export const PRINTABLE_VOCABULARY_STATUSES = [
+    "active",
+    "text_ready",
+    "review",
+] as const satisfies readonly VocabularyStatus[];
+
+export type PrintableVocabularyStatus = (typeof PRINTABLE_VOCABULARY_STATUSES)[number];
+
+export function isPrintableVocabulary(item: VocabularyItemDTO): boolean {
+    return (PRINTABLE_VOCABULARY_STATUSES as readonly VocabularyStatus[]).includes(item.status);
+}
+
+export interface WordListDocumentData {
+    sessionName: string;
+    lessonName: string;
+    words: VocabularyItemDTO[];
+    meta: DocumentMeta;
+}


### PR DESCRIPTION
- Added a new print feature for bank statements, including a dedicated print drawer and document layout.
- Introduced components for rendering bank statement documents, including headers, footers, and transaction tables.
- Implemented utility functions for generating print file names and managing print document lifecycle.
- Enhanced existing components to support printing capabilities, ensuring a clean and formatted output for users.

## Summary

<!-- Briefly describe the goal of this PR. What is the business/architectural value? -->

## Ticket Link

<!-- Link to Jira / Linear / GitHub Issue (e.g., ENT-142) -->

## Type of Change

- [x] ✨ Feature  
- [ ] 🐛 Bug Fix  
- [ ] 🛠 Refactor  
- [ ] 📚 Documentation  
- [ ] 🧪 Testing  
- [ ] 🚀 Hotfix  

## Changes Made

<!-- List of specific modifications in bulleted format -->

- 💎 **Architecture**: (e.g., Migrated auth logic to Service layer)
- 📡 **Routes**: (e.g., Added GET /api/v1/playlists)
- 🗄️ **Database**: (e.g., New columns added to playlists table)
- 🎨 **UI**: (e.g., Updated sidebar UI for mobile responsive)

## How to Test

<!-- Step-by-step instructions for the reviewer. List specific test inputs or URLs. -->

1. 🌐 Navigate to `/org/:slug/dashboard`
2. 🖱️ Click "Add Playlist"
3. ✅ Confirm the playlist appears in the database and list

## Risks / Rollback Notes

- [ ] New environment variables added
- [ ] Database migration required
- [ ] High impact to existing functionality

## Screenshots (If UI changed)

<!-- Drop before/after screenshots here -->

---

## 🏗 Checklist

- [ ] **Typecheck**: `npm run typecheck:api` passes.
- [ ] **Tests**: `npm run test:api` (or relevant unit tests) passes.
- [ ] **Patterns**: No direct repository access from handlers. All DB logic is in Services.
- [ ] **Boundaries**: No external clients (Better Auth, Stripe, etc.) in Repositories.
- [ ] **Resilience**: `get*` methods have corresponding `NotFoundError` test cases.
- [ ] **Documentation**: `docs/` updated if new architecture patterns were introduced.
- [ ] **AI Context**: `docs/AI.md` updated if canonical rules changed.
