### PR TITLE
feat: enhance vocabulary processing and UI for IPA handling

### DIFF
--- a/api/services/vocabulary-processing.service.ts
+++ b/api/services/vocabulary-processing.service.ts
@@ -272,7 +272,7 @@ export class VocabularyProcessingService {
 function stripIpaSlashes(s: string): string {
     return s
         .trim()
-        .replace(/^\/|\/$/g, "")
+        .replace(/^\/+|\/+$/g, "")
         .trim();
 }
 

--- a/api/services/vocabulary-processing.service.ts
+++ b/api/services/vocabulary-processing.service.ts
@@ -26,9 +26,17 @@ export const VOCABULARY_TRANSLATION_SCHEMA: AiJsonSchema = {
         },
         zh_translation: { type: "string" },
         needs_language_review: { type: "boolean" },
-        ipa_us: { type: "string" },
+        ipa_us: {
+            type: "string",
+            description:
+                "American English IPA transcription of the phrase, no surrounding slashes (e.g. ˈmɪl.jən).",
+        },
         syllables_en: { type: "string" },
-        syllables_ipa: { type: "string" },
+        syllables_ipa: {
+            type: "string",
+            description:
+                "IPA with hyphen-separated syllables within each word, spaces preserved between words, no surrounding slashes (e.g. ˈmɪl-jən).",
+        },
         definition_simple: { type: "string" },
     },
     required: [
@@ -57,9 +65,9 @@ export const VOCABULARY_TRANSLATION_INSTRUCTIONS = [
     "1. Return 'normalized_text' as the canonical form: capitalize proper nouns (e.g. 'China', 'iPhone'), lowercase common nouns/verbs (e.g. 'apple', 'run').",
     "2. Return 'zh_translation' in Simplified Chinese characters (not English, never empty).",
     "3. If uncertain about translation quality, still provide your best translation and set 'needs_language_review' to true.",
-    "4. Return 'ipa_us' as the American English IPA transcription of the phrase.",
+    "4. Return 'ipa_us' as the American English IPA transcription, without surrounding slashes (e.g. ˈmɪl.jən not /ˈmɪl.jən/).",
     "5. Return 'syllables_en' as the phrase with hyphen-separated syllables within each word, spaces preserved between words.",
-    "6. Return 'syllables_ipa' as the IPA transcription with hyphen-separated syllables within each word, spaces preserved between words.",
+    "6. Return 'syllables_ipa' as the IPA transcription with hyphen-separated syllables within each word, spaces preserved between words, without surrounding slashes.",
     "7. Return 'definition_simple' as a 1-sentence definition a 7-year-old can understand.",
 ].join("\n");
 
@@ -260,6 +268,14 @@ export class VocabularyProcessingService {
  * Runtime type guard for model output.
  * With response_format json_schema enabled, this is defensive validation rather than extraction.
  */
+/** Defensive unwrap when the model echoes IPA with orthographic slashes (any leading/trailing slash, not only a matched pair). */
+function stripIpaSlashes(s: string): string {
+    return s
+        .trim()
+        .replace(/^\/|\/$/g, "")
+        .trim();
+}
+
 function parseVocabularyTranslation(raw: string, fallbackText?: string): VocabularyTranslation {
     const parsed = JSON.parse(raw) as Partial<VocabularyTranslation>;
 
@@ -272,14 +288,19 @@ function parseVocabularyTranslation(raw: string, fallbackText?: string): Vocabul
         parsed.zh_translation.length === 0 ||
         typeof parsed.needs_language_review !== "boolean" ||
         typeof parsed.ipa_us !== "string" ||
-        parsed.ipa_us.length === 0 ||
         typeof parsed.syllables_en !== "string" ||
         parsed.syllables_en.length === 0 ||
         typeof parsed.syllables_ipa !== "string" ||
-        parsed.syllables_ipa.length === 0 ||
         typeof parsed.definition_simple !== "string" ||
         parsed.definition_simple.length === 0
     ) {
+        throw new InternalServerError("Invalid translation payload from AI");
+    }
+
+    const ipa_us = stripIpaSlashes(parsed.ipa_us);
+    const syllables_ipa = stripIpaSlashes(parsed.syllables_ipa);
+
+    if (ipa_us.length === 0 || syllables_ipa.length === 0) {
         throw new InternalServerError("Invalid translation payload from AI");
     }
 
@@ -287,9 +308,9 @@ function parseVocabularyTranslation(raw: string, fallbackText?: string): Vocabul
         normalized_text,
         zh_translation: parsed.zh_translation,
         needs_language_review: parsed.needs_language_review,
-        ipa_us: parsed.ipa_us,
+        ipa_us,
         syllables_en: parsed.syllables_en,
-        syllables_ipa: parsed.syllables_ipa,
+        syllables_ipa,
         definition_simple: parsed.definition_simple,
     };
 }

--- a/tests/unit/vocabulary-processing.service.test.ts
+++ b/tests/unit/vocabulary-processing.service.test.ts
@@ -66,7 +66,7 @@ describe("VocabularyProcessingService", () => {
         needs_language_review: false,
         ipa_us: "/hello/",
         syllables_en: "hel-lo",
-        syllables_ipa: "hel-lo",
+        syllables_ipa: "/hel-lo/",
         definition_simple: "A greeting",
     };
 
@@ -101,13 +101,46 @@ describe("VocabularyProcessingService", () => {
             zhTranslation: "你好",
             pinyin: "nǐ hǎo",
             needsLanguageReview: false,
-            ipaUs: "/hello/",
+            ipaUs: "hello",
             syllablesEn: "hel-lo",
             syllablesIpa: "hel-lo",
             definitionSimple: "A greeting",
         });
         expect(vocabRepo.updateStatus).not.toHaveBeenCalledWith("vocab_1", "active");
         expect(ttsService.generateAndUpload).not.toHaveBeenCalled();
+    });
+
+    it("processText strips asymmetric IPA slashes on ipa_us and syllables_ipa", async () => {
+        vocabRepo.findById.mockResolvedValueOnce({
+            id: "vocab_1",
+            text: "hello",
+            status: "new",
+        });
+        aiService.generate.mockResolvedValueOnce({
+            text: JSON.stringify({
+                ...MOCK_SUCCESS_RESULT,
+                ipa_us: "/hello",
+                syllables_ipa: "hel-lo/",
+            }),
+        });
+        vocabRepo.update.mockResolvedValue({});
+        vocabRepo.updateStatus.mockResolvedValue({});
+
+        const service = new VocabularyProcessingService(
+            vocabRepo as never,
+            aiService as never,
+            ttsService as never,
+            undefined
+        );
+        await service.processText("vocab_1");
+
+        expect(vocabRepo.update).toHaveBeenCalledWith(
+            "vocab_1",
+            expect.objectContaining({
+                ipaUs: "hello",
+                syllablesIpa: "hel-lo",
+            })
+        );
     });
 
     it("processText sets review only when AI flags language quality", async () => {

--- a/tests/unit/vocabulary-processing.service.test.ts
+++ b/tests/unit/vocabulary-processing.service.test.ts
@@ -143,6 +143,39 @@ describe("VocabularyProcessingService", () => {
         );
     });
 
+    it("processText strips repeated leading/trailing IPA slashes in one pass", async () => {
+        vocabRepo.findById.mockResolvedValueOnce({
+            id: "vocab_1",
+            text: "thunder",
+            status: "new",
+        });
+        aiService.generate.mockResolvedValueOnce({
+            text: JSON.stringify({
+                ...MOCK_SUCCESS_RESULT,
+                ipa_us: "//ˈθʌndər//",
+                syllables_ipa: "///ˈθʌn-dər///",
+            }),
+        });
+        vocabRepo.update.mockResolvedValue({});
+        vocabRepo.updateStatus.mockResolvedValue({});
+
+        const service = new VocabularyProcessingService(
+            vocabRepo as never,
+            aiService as never,
+            ttsService as never,
+            undefined
+        );
+        await service.processText("vocab_1");
+
+        expect(vocabRepo.update).toHaveBeenCalledWith(
+            "vocab_1",
+            expect.objectContaining({
+                ipaUs: "ˈθʌndər",
+                syllablesIpa: "ˈθʌn-dər",
+            })
+        );
+    });
+
     it("processText sets review only when AI flags language quality", async () => {
         vocabRepo.findById.mockResolvedValueOnce({
             id: "vocab_1",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineWorkersConfig({
     test: {
+        /** Integration hooks (D1 + auth) occasionally exceed Vitest’s default 10s under load. */
+        hookTimeout: 30_000,
         setupFiles: ["./tests/setup.ts"],
         poolOptions: {
             workers: {

--- a/web/src/features/ai/components/VocabAiTester/VocabAiResultCard.tsx
+++ b/web/src/features/ai/components/VocabAiTester/VocabAiResultCard.tsx
@@ -1,3 +1,4 @@
+import { IpaBracketed } from "@web/src/features/vocabulary/components/IpaBracketed";
 import { App, Badge, Button, Card, List, Space, Table, Tabs, Tag, Typography, theme } from "antd";
 import type { VocabAiTestResult } from "../../hooks/ai.hooks";
 
@@ -20,9 +21,12 @@ export function VocabAiResultCard({ result, elapsed }: Props) {
     const formattedItems = [
         { label: "zh_translation", value: result.result.zh_translation, strong: true },
         { label: "pinyin", value: result.result.pinyin },
-        { label: "ipa_us", value: result.result.ipa_us },
+        { label: "ipa_us", value: <IpaBracketed value={result.result.ipa_us} /> },
         { label: "syllables_en", value: result.result.syllables_en },
-        { label: "syllables_ipa", value: result.result.syllables_ipa },
+        {
+            label: "syllables_ipa",
+            value: <IpaBracketed value={result.result.syllables_ipa} />,
+        },
         { label: "definition_simple", value: result.result.definition_simple },
         {
             label: "needs_language_review",

--- a/web/src/features/vocabulary/components/IpaBracketed.tsx
+++ b/web/src/features/vocabulary/components/IpaBracketed.tsx
@@ -4,7 +4,13 @@ type Props = { value: string | null | undefined };
  * Stored IPA omits wrapping slashes (see vocabulary pipeline normalization); conventional display wraps with /…/.
  */
 export function IpaBracketed({ value }: Props) {
-    const trimmed = typeof value === "string" ? value.trim() : "";
+    const trimmed =
+        typeof value === "string"
+            ? value
+                  .trim()
+                  .replace(/^\/+|\/+$/g, "")
+                  .trim()
+            : "";
     if (!trimmed) return <span className="ipa">—</span>;
     return <span className="ipa">{`/${trimmed}/`}</span>;
 }

--- a/web/src/features/vocabulary/components/IpaBracketed.tsx
+++ b/web/src/features/vocabulary/components/IpaBracketed.tsx
@@ -1,0 +1,10 @@
+type Props = { value: string | null | undefined };
+
+/**
+ * Stored IPA omits wrapping slashes (see vocabulary pipeline normalization); conventional display wraps with /…/.
+ */
+export function IpaBracketed({ value }: Props) {
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    if (!trimmed) return <span className="ipa">—</span>;
+    return <span className="ipa">{`/${trimmed}/`}</span>;
+}

--- a/web/src/features/vocabulary/components/VocabularyTable.tsx
+++ b/web/src/features/vocabulary/components/VocabularyTable.tsx
@@ -12,6 +12,7 @@ import { dedupeSessionVocabularyByWord } from "@web/src/features/vocabulary/util
 import { Button, Empty, Popconfirm, Space, Table, Tag, Typography } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import { useMemo } from "react";
+import { IpaBracketed } from "./IpaBracketed";
 import { VocabAudioCell } from "./VocabAudioCell";
 import { VocabularyStatusBadge } from "./VocabularyStatusBadge";
 
@@ -106,7 +107,7 @@ export function VocabularyTable({
                 title: "IPA",
                 key: "ipaUs",
                 width: 120,
-                render: (_, record) => getVocab(record).ipaUs || "—",
+                render: (_, record) => <IpaBracketed value={getVocab(record).ipaUs} />,
             },
             {
                 title: "Definition",

--- a/web/src/features/vocabulary/components/__tests__/IpaBracketed.test.tsx
+++ b/web/src/features/vocabulary/components/__tests__/IpaBracketed.test.tsx
@@ -1,0 +1,15 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { IpaBracketed } from "../IpaBracketed";
+
+describe("IpaBracketed", () => {
+    it("strips slashes from stored value before wrapping", () => {
+        const { container } = render(<IpaBracketed value="/ˈθʌndər/" />);
+        expect(container.textContent).toBe("/ˈθʌndər/");
+    });
+
+    it("handles bare value correctly", () => {
+        const { container } = render(<IpaBracketed value="ˈθʌndər" />);
+        expect(container.textContent).toBe("/ˈθʌndər/");
+    });
+});

--- a/web/src/pages/teaching/vocabulary/GlobalVocabularyPage.tsx
+++ b/web/src/pages/teaching/vocabulary/GlobalVocabularyPage.tsx
@@ -3,6 +3,7 @@ import type { CursorPaginationConfig } from "@web/src/components/data/DataTable.
 import { DataTableWithFilters } from "@web/src/components/data/DataTableWithFilters";
 import { PageHeader } from "@web/src/components/layout/PageHeader";
 import { useOrganization } from "@web/src/features/organization";
+import { IpaBracketed } from "@web/src/features/vocabulary/components/IpaBracketed";
 import { VocabularyEditDrawer } from "@web/src/features/vocabulary/components/VocabularyEditDrawer";
 import { VocabularyStatusBadge } from "@web/src/features/vocabulary/components/VocabularyStatusBadge";
 import {
@@ -116,7 +117,7 @@ export default function GlobalVocabularyPage() {
             dataIndex: "ipaUs",
             key: "ipaUs",
             width: 120,
-            render: (text: string) => text || "—",
+            render: (text: string | null | undefined) => <IpaBracketed value={text} />,
         },
         {
             title: "Definition",

--- a/web/src/reports/core/print.css
+++ b/web/src/reports/core/print.css
@@ -137,6 +137,14 @@
         border: 0.5pt solid #d0d0d0;
     }
 
+    /* IPA glyphs and combining marks — stack ahead of Arial so printed word lists resolve tone marks reliably. */
+    #print-root .ipa,
+    body > #print-root .ipa {
+        font-family:
+            "Charis SIL", "Doulos SIL", "Gentium Plus", "Noto Sans IPA", Arial, sans-serif !important;
+        color: #444 !important;
+    }
+
     /* Strip decoration only inside the print document — leaving the rest
      * of the page (which is hidden anyway) untouched. Scoped so specificity
      * matches the other #print-root rules above. */

--- a/web/src/reports/templates/word-list/WordListRow.tsx
+++ b/web/src/reports/templates/word-list/WordListRow.tsx
@@ -1,3 +1,4 @@
+import { IpaBracketed } from "@web/src/features/vocabulary/components/IpaBracketed";
 import type { VocabularyItemDTO } from "@web/src/features/vocabulary/hooks/useVocabulary";
 
 interface WordListRowProps {
@@ -14,7 +15,7 @@ export function WordListRow({ word, index }: WordListRowProps) {
              * between the visible text and the browser's hit-test layer, which
              * made selection land in apparently empty space. */}
             <td style={{ width: "18%", fontFamily: "Arial, sans-serif", color: "#444" }}>
-                {word.ipaUs ?? ""}
+                <IpaBracketed value={word.ipaUs} />
             </td>
             <td style={{ width: "38%", color: "#222" }}>{word.definitionSimple ?? ""}</td>
             <td style={{ width: "18%" }}>{word.zhTranslation ?? ""}</td>


### PR DESCRIPTION
- Updated the vocabulary translation schema to include descriptions for `ipa_us` and `syllables_ipa`.
- Implemented a function to strip surrounding slashes from IPA transcriptions in the processing logic.
- Modified unit tests to validate the new behavior of stripping slashes from IPA fields.
- Introduced a new `IpaBracketed` component for consistent display of IPA values across the UI, ensuring they are wrapped in slashes when rendered.
- Updated various components to utilize the `IpaBracketed` component for displaying IPA values, enhancing UI consistency.

## Summary

<!-- Briefly describe the goal of this PR. What is the business/architectural value? -->

## Ticket Link

<!-- Link to Jira / Linear / GitHub Issue (e.g., ENT-142) -->

## Type of Change

- [x] ✨ Feature  
- [ ] 🐛 Bug Fix  
- [ ] 🛠 Refactor  
- [ ] 📚 Documentation  
- [ ] 🧪 Testing  
- [ ] 🚀 Hotfix  

## Changes Made

<!-- List of specific modifications in bulleted format -->

- 💎 **Architecture**: (e.g., Migrated auth logic to Service layer)
- 📡 **Routes**: (e.g., Added GET /api/v1/playlists)
- 🗄️ **Database**: (e.g., New columns added to playlists table)
- 🎨 **UI**: (e.g., Updated sidebar UI for mobile responsive)

## How to Test

<!-- Step-by-step instructions for the reviewer. List specific test inputs or URLs. -->

1. 🌐 Navigate to `/org/:slug/dashboard`
2. 🖱️ Click "Add Playlist"
3. ✅ Confirm the playlist appears in the database and list

## Risks / Rollback Notes

- [ ] New environment variables added
- [ ] Database migration required
- [ ] High impact to existing functionality

## Screenshots (If UI changed)

<!-- Drop before/after screenshots here -->

---

## 🏗 Checklist

- [ ] **Typecheck**: `npm run typecheck:api` passes.
- [ ] **Tests**: `npm run test:api` (or relevant unit tests) passes.
- [ ] **Patterns**: No direct repository access from handlers. All DB logic is in Services.
- [ ] **Boundaries**: No external clients (Better Auth, Stripe, etc.) in Repositories.
- [ ] **Resilience**: `get*` methods have corresponding `NotFoundError` test cases.
- [ ] **Documentation**: `docs/` updated if new architecture patterns were introduced.
- [ ] **AI Context**: `docs/AI.md` updated if canonical rules changed.
