### PR TITLE
refactor: optimize filter handling in DataTableWithFilters and relate…

### DIFF
--- a/apps/docs/frontend/02-unified-filter-bar.md
+++ b/apps/docs/frontend/02-unified-filter-bar.md
@@ -63,7 +63,10 @@ When built-in filter types are not enough, use `customRender` in `FilterConfig`:
 - For URL-backed filters:
   - Compare next params against current params and return early if unchanged.
   - Use deterministic serialization (`toISOString` for date values).
+  - Prefer `setSearchParams(prev => …)` and do **not** list `searchParams` as an effect dependency (feedback loops).
+  - Seed search from the URL **once on mount**. Never pass a fresh `initialFilters={{ search: urlValue }}` object every render into `DataTableWithFilters` — that used to reset the input mid-typing.
 - Keep `useEffect` dependencies explicit and value-based (not unstable object/function references).
+- `DataTableWithFilters` uses `initialFilters` only as the mount seed and Reset target; it does not re-apply them on every parent render.
 
 ## Migration Checklist
 

--- a/apps/web/src/components/data/DataTableWithFilters.tsx
+++ b/apps/web/src/components/data/DataTableWithFilters.tsx
@@ -1,7 +1,7 @@
 import { InboxOutlined } from "@ant-design/icons";
 import type { TableProps } from "antd";
 import { Table, theme } from "antd";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import type { ClientPaginationConfig, CursorPaginationConfig } from "./DataTable.types";
 import { DataTablePagination } from "./DataTablePagination";
 import { FilterBar, type FilterConfig } from "./FilterBar";
@@ -67,11 +67,14 @@ function DataTableWithFiltersInternal<T extends object>({
         tableProps,
     } = config;
 
-    const [localFilters, setLocalFilters] = useState<Record<string, any>>(initialFilters ?? {});
+    const [localFilters, setLocalFilters] = useState<Record<string, any>>(
+        () => initialFilters ?? {}
+    );
 
-    useEffect(() => {
-        setLocalFilters(initialFilters ?? {});
-    }, [initialFilters]);
+    // Do NOT sync `initialFilters` → local state on every parent render.
+    // Inline `initialFilters={{ search: ... }}` objects are new references each render;
+    // resetting here overwrote in-progress search typing (skipped/lagging characters).
+    // `initialFilters` is only the mount seed and the Reset target.
 
     const handleFiltersChange = useCallback(
         (newFilters: Record<string, any>) => {

--- a/apps/web/src/features/media/components/MediaLibraryTable.tsx
+++ b/apps/web/src/features/media/components/MediaLibraryTable.tsx
@@ -15,7 +15,7 @@ import { UI_CONSTANTS } from "@web/src/utils/constants";
 import type { MenuProps } from "antd";
 import { Button, Drawer, Dropdown, Form, Input, Space, Tooltip, Typography, theme } from "antd";
 import type React from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useMedia } from "../hooks/useMedia";
 import { useRecordMediaPlay } from "../hooks/useRecordMediaPlay";
 import { CoverArtUploader } from "./CoverArtUploader";
@@ -35,6 +35,7 @@ interface MediaLibraryTableProps {
 export const MediaLibraryTable: React.FC<MediaLibraryTableProps> = ({ defaultType = "all" }) => {
     const { token } = theme.useToken();
     const [form] = Form.useForm();
+    const mediaInitialFilters = useMemo(() => ({ type: defaultType }), [defaultType]);
 
     const {
         filters,
@@ -47,7 +48,7 @@ export const MediaLibraryTable: React.FC<MediaLibraryTableProps> = ({ defaultTyp
         onNext,
         onPrev,
     } = useCursorTableState<MediaFilters>({
-        initialFilters: { type: defaultType },
+        initialFilters: mediaInitialFilters,
     });
 
     const filterType = filters.type ?? "all";
@@ -176,7 +177,7 @@ export const MediaLibraryTable: React.FC<MediaLibraryTableProps> = ({ defaultTyp
                         data: media,
                         loading,
                         onRowClick: handlePlayMedia,
-                        initialFilters: { type: defaultType },
+                        initialFilters: mediaInitialFilters,
                         filters: [
                             {
                                 type: "search",

--- a/apps/web/src/features/schedule/hooks/useScheduleState.ts
+++ b/apps/web/src/features/schedule/hooks/useScheduleState.ts
@@ -23,12 +23,17 @@ export const useScheduleState = (organizationId?: string) => {
     // Sync defaults to URL
     useEffect(() => {
         if (!startDateParam || !endDateParam) {
-            const params = new URLSearchParams(searchParams);
-            params.set("startDate", queryStart.toString());
-            params.set("endDate", queryEnd.toString());
-            setSearchParams(params, { replace: true });
+            setSearchParams(
+                (prev) => {
+                    const params = new URLSearchParams(prev);
+                    params.set("startDate", queryStart.toString());
+                    params.set("endDate", queryEnd.toString());
+                    return params;
+                },
+                { replace: true }
+            );
         }
-    }, [startDateParam, endDateParam, searchParams, setSearchParams, queryStart, queryEnd]);
+    }, [startDateParam, endDateParam, setSearchParams, queryStart, queryEnd]);
 
     // Search logic
     const [localSearch, setLocalSearch] = useState(searchParams.get("q") || "");
@@ -39,11 +44,19 @@ export const useScheduleState = (organizationId?: string) => {
     );
 
     useEffect(() => {
-        const params = new URLSearchParams(searchParams);
-        if (debouncedSearch) params.set("q", debouncedSearch);
-        else params.delete("q");
-        setSearchParams(params, { replace: true });
-    }, [debouncedSearch, searchParams, setSearchParams]);
+        setSearchParams(
+            (prev) => {
+                const params = new URLSearchParams(prev);
+                const current = prev.get("q") ?? "";
+                const desired = debouncedSearch || "";
+                if (current === desired) return prev;
+                if (desired) params.set("q", desired);
+                else params.delete("q");
+                return params;
+            },
+            { replace: true }
+        );
+    }, [debouncedSearch, setSearchParams]);
 
     // Timeline filtering
     const [timeline, setTimeline] = useState<TimelineFilter>("Upcoming");

--- a/apps/web/src/pages/organization/OrganizationMembersPage.tsx
+++ b/apps/web/src/pages/organization/OrganizationMembersPage.tsx
@@ -72,9 +72,13 @@ export const OrganizationMembersPage: React.FC<{ canManage?: boolean }> = ({
     const { notification } = App.useApp();
     const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
 
-    // Bind search state generically to url string matching native architecture persistence
+    // Seed search from URL once (mount). Do not re-bind to URL on every param change —
+    // that fought the live input and dropped keystrokes after debounce wrote to the URL.
     const [searchParams, setSearchParams] = useSearchParams();
-    const initialSearch = searchParams.get("search") || searchParams.get("q") || "";
+    const [membersInitialFilters] = useState(() => {
+        const fromUrl = searchParams.get("search") || searchParams.get("q") || "";
+        return { search: fromUrl || undefined };
+    });
 
     const {
         debouncedSearch,
@@ -86,20 +90,27 @@ export const OrganizationMembersPage: React.FC<{ canManage?: boolean }> = ({
         onNext,
         onPrev,
     } = useCursorTableState<{ search?: string }>({
-        initialFilters: { search: initialSearch || undefined },
+        initialFilters: membersInitialFilters,
     });
 
-    // Sync to URL safely automatically reliably neatly explicitly
+    // Sync debounced search → URL without depending on searchParams (avoids feedback loops).
     useEffect(() => {
-        const newParams = new URLSearchParams(searchParams);
-        if (debouncedSearch) {
-            newParams.set("search", debouncedSearch);
-        } else {
-            newParams.delete("search");
-        }
-        newParams.delete("q");
-        setSearchParams(newParams, { replace: true });
-    }, [debouncedSearch, setSearchParams, searchParams]);
+        setSearchParams(
+            (prev) => {
+                const next = new URLSearchParams(prev);
+                const current = prev.get("search") ?? "";
+                const desired = debouncedSearch || "";
+                if (current === desired && !prev.has("q")) {
+                    return prev;
+                }
+                if (desired) next.set("search", desired);
+                else next.delete("search");
+                next.delete("q");
+                return next;
+            },
+            { replace: true }
+        );
+    }, [debouncedSearch, setSearchParams]);
 
     const [createForm] = Form.useForm();
     // Store only the ID — the drawer derives live data from the members cache
@@ -393,7 +404,7 @@ export const OrganizationMembersPage: React.FC<{ canManage?: boolean }> = ({
                             },
                         ],
                         onFiltersChange,
-                        initialFilters: { search: initialSearch || undefined },
+                        initialFilters: membersInitialFilters,
                         pagination: {
                             hasNextPage,
                             hasPrevPage: cursorStack.length > 0,


### PR DESCRIPTION
…d components

- Updated DataTableWithFilters to prevent unnecessary re-renders by using initialFilters only as a mount seed and reset target.
- Enhanced URL-backed filter logic to avoid feedback loops and ensure smoother user input handling.
- Refactored MediaLibraryTable and OrganizationMembersPage to utilize memoized initialFilters for improved performance and consistency.
- Streamlined search parameter synchronization in useScheduleState to prevent redundant updates and maintain input integrity.

## Summary

<!-- Briefly describe the goal of this PR. What is the business/architectural value? -->

## Ticket Link

<!-- Link to Jira / Linear / GitHub Issue (e.g., ENT-142) -->

## Type of Change

- [x] ✨ Feature  
- [ ] 🐛 Bug Fix  
- [ ] 🛠 Refactor  
- [ ] 📚 Documentation  
- [ ] 🧪 Testing  
- [ ] 🚀 Hotfix  

## Changes Made

<!-- List of specific modifications in bulleted format -->

- 💎 **Architecture**: (e.g., Migrated auth logic to Service layer)
- 📡 **Routes**: (e.g., Added GET /api/v1/playlists)
- 🗄️ **Database**: (e.g., New columns added to playlists table)
- 🎨 **UI**: (e.g., Updated sidebar UI for mobile responsive)

## How to Test

<!-- Step-by-step instructions for the reviewer. List specific test inputs or URLs. -->

1. 🌐 Navigate to `/org/:slug/dashboard`
2. 🖱️ Click "Add Playlist"
3. ✅ Confirm the playlist appears in the database and list

## Risks / Rollback Notes

- [ ] New environment variables added
- [ ] Database migration required
- [ ] High impact to existing functionality

## Screenshots (If UI changed)

<!-- Drop before/after screenshots here -->

---

## 🏗 Checklist

- [ ] **Typecheck**: `npm run typecheck:api` passes.
- [ ] **Tests**: `npm run test:api` (or relevant unit tests) passes.
- [ ] **Patterns**: No direct repository access from handlers. All DB logic is in Services.
- [ ] **Boundaries**: No external clients (Better Auth, Stripe, etc.) in Repositories.
- [ ] **Resilience**: `get*` methods have corresponding `NotFoundError` test cases.
- [ ] **Documentation**: `apps/docs/` updated if new architecture patterns were introduced.
- [ ] **AI Context**: `apps/docs/AI.md` updated if canonical rules changed.
